### PR TITLE
feat: Add RBAC permissioning to CapAutomator (DEV-1076)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Filter directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' 'script/*' --output-file lcov.info --rc lcov_branch_coverage=1
+          lcov --remove lcov.info 'test/*' 'script/*' --output-file lcov.info --rc lcov_branch_coverage=1 --ignore-errors unused
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -28,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -47,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/aave-v3-core"]
 	path = lib/aave-v3-core
 	url = https://github.com/marsfoundation/aave-v3-core
+[submodule "lib/spark-address-registry"]
+	path = lib/spark-address-registry
+	url = https://github.com/sparkdotfi/spark-address-registry

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/marsfoundation/aave-v3-core
 [submodule "lib/spark-address-registry"]
 	path = lib/spark-address-registry
-	url = https://github.com/sparkdotfi/spark-address-registry
+	url = https://github.com/lib/spark-address-registry

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/marsfoundation/aave-v3-core
 [submodule "lib/spark-address-registry"]
 	path = lib/spark-address-registry
-	url = https://github.com/lib/spark-address-registry
+	url = https://github.com/sparkdotfi/spark-address-registry

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,14 +2,9 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-solc_version = '0.8.20'
+solc_version = '0.8.22'
 optimizer = true
 optimizer_runs = 200
-remappings = [
-    "openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/",
-    "aave-v3-core-contracts/=lib/aave-v3-core/contracts/",
-    "spark-address-registry/=lib/spark-address-registry/src/"
-]
 
 [fuzz]
 runs = 1000

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,8 @@ optimizer = true
 optimizer_runs = 200
 remappings = [
     "openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/",
-    "aave-v3-core-contracts/=lib/aave-v3-core/contracts/"
+    "aave-v3-core-contracts/=lib/aave-v3-core/contracts/",
+    "spark-address-registry/=lib/spark-address-registry/src/"
 ]
 
 [fuzz]

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,7 @@ optimizer = true
 optimizer_runs = 200
 remappings = [
     "openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/",
+    "aave-v3-core-contracts/=lib/aave-v3-core/contracts/"
 ]
 
 [fuzz]

--- a/src/CapAutomator.sol
+++ b/src/CapAutomator.sol
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
-import { AccessControlEnumerable } from "openzeppelin-contracts/access/extensions/AccessControlEnumerable.sol";
-import { IERC20 }                  from "openzeppelin-contracts/interfaces/IERC20.sol";
-import { IERC20Metadata }          from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
+import { AccessControlEnumerable } from "../lib/openzeppelin-contracts/contracts/access/extensions/AccessControlEnumerable.sol";
 
-import { ReserveConfiguration }   from "aave-v3-core-contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
-import { DataTypes }              from "aave-v3-core-contracts/protocol/libraries/types/DataTypes.sol";
-import { WadRayMath }             from "aave-v3-core-contracts/protocol/libraries/math/WadRayMath.sol";
-import { IPoolAddressesProvider } from "aave-v3-core-contracts/interfaces/IPoolAddressesProvider.sol";
-import { IPool }                  from "aave-v3-core-contracts/interfaces/IPool.sol";
-import { IPoolConfigurator }      from "aave-v3-core-contracts/interfaces/IPoolConfigurator.sol";
-import { IScaledBalanceToken }    from "aave-v3-core-contracts/interfaces/IScaledBalanceToken.sol";
+import { ReserveConfiguration } from "../lib/aave-v3-core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
+import { DataTypes }            from "../lib/aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
+import { WadRayMath }           from "../lib/aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol";
 
 import { ICapAutomator } from "./interfaces/ICapAutomator.sol";
+import { IERC20Like }    from "./interfaces/Common.sol";
+
+import {
+    IPoolAddressesProviderLike,
+    IPoolConfiguratorLike,
+    IPoolLike,
+    IScaledBalanceTokenLike
+} from "./interfaces/IAAVEV3.sol";
 
 contract CapAutomator is ICapAutomator, AccessControlEnumerable {
 
@@ -32,13 +34,13 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         uint48 lastIncreaseTime; // Seconds
     }
 
-    mapping(address => CapConfig) public override supplyCapConfigs;
-    mapping(address => CapConfig) public override borrowCapConfigs;
-
-    IPoolConfigurator public override immutable poolConfigurator;
-    IPool             public override immutable pool;
-
     bytes32 public constant UPDATE_ROLE = keccak256("UPDATE_ROLE");
+
+    address public immutable poolConfigurator;
+    address public immutable pool;
+
+    mapping(address => CapConfig) public supplyCapConfigs;
+    mapping(address => CapConfig) public borrowCapConfigs;
 
     constructor(address poolAddressesProvider, address admin, address updater)  {
         require(admin   != address(0), "CapAutomator/invalid-admin-address");
@@ -47,13 +49,8 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(UPDATE_ROLE,        updater);
 
-        pool = IPool(
-            IPoolAddressesProvider(poolAddressesProvider).getPool()
-        );
-
-        poolConfigurator = IPoolConfigurator(
-            IPoolAddressesProvider(poolAddressesProvider).getPoolConfigurator()
-        );
+        pool             = IPoolAddressesProviderLike(poolAddressesProvider).getPool();
+        poolConfigurator = IPoolAddressesProviderLike(poolAddressesProvider).getPoolConfigurator();
     }
 
     /**********************************************************************************************/
@@ -83,12 +80,7 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
             supplyCapConfigs[asset].lastIncreaseTime
         );
 
-        emit SetSupplyCapConfig(
-            asset,
-            max,
-            gap,
-            increaseCooldown
-        );
+        emit SetSupplyCapConfig(asset, max, gap, increaseCooldown);
     }
 
     function setBorrowCapConfig(
@@ -114,19 +106,10 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
             borrowCapConfigs[asset].lastIncreaseTime
         );
 
-        emit SetBorrowCapConfig(
-            asset,
-            max,
-            gap,
-            increaseCooldown
-        );
+        emit SetBorrowCapConfig(asset, max, gap, increaseCooldown);
     }
 
-    function removeSupplyCapConfig(address asset)
-        external
-        override
-        onlyRole(DEFAULT_ADMIN_ROLE)
-    {
+    function removeSupplyCapConfig(address asset) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         require(supplyCapConfigs[asset].max > 0, "CapAutomator/nonexistent-config");
 
         delete supplyCapConfigs[asset];
@@ -134,11 +117,7 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         emit RemoveSupplyCapConfig(asset);
     }
 
-    function removeBorrowCapConfig(address asset)
-        external
-        override
-        onlyRole(DEFAULT_ADMIN_ROLE)
-    {
+    function removeBorrowCapConfig(address asset) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         require(borrowCapConfigs[asset].max > 0, "CapAutomator/nonexistent-config");
 
         delete borrowCapConfigs[asset];
@@ -150,21 +129,11 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
     /*** Updater Functions                                                                      ***/
     /**********************************************************************************************/
 
-    function execSupply(address asset)
-        external
-        override
-        onlyRole(UPDATE_ROLE)
-        returns (uint256) 
-    {
+    function execSupply(address asset) external override onlyRole(UPDATE_ROLE) returns (uint256) {
         return _updateSupplyCap(asset);
     }
 
-    function execBorrow(address asset)
-        external
-        override
-        onlyRole(UPDATE_ROLE)
-        returns (uint256) 
-    {
+    function execBorrow(address asset) external override onlyRole(UPDATE_ROLE) returns (uint256) {
         return _updateBorrowCap(asset);
     }
 
@@ -212,16 +181,16 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
     }
 
     function _updateSupplyCap(address asset) internal returns (uint256) {
-        DataTypes.ReserveData memory reserveData = pool.getReserveData(asset);
+        DataTypes.ReserveData memory reserveData = IPoolLike(pool).getReserveData(asset);
         CapConfig             memory capConfig   = supplyCapConfigs[asset];
 
         uint256 currentSupplyCap = reserveData.configuration.getSupplyCap();
 
         uint256 currentSupply = (
-                IScaledBalanceToken(reserveData.aTokenAddress).scaledTotalSupply()
+                IScaledBalanceTokenLike(reserveData.aTokenAddress).scaledTotalSupply()
                 + uint256(reserveData.accruedToTreasury)
             ).rayMul(reserveData.liquidityIndex)
-            / 10 ** IERC20Metadata(reserveData.aTokenAddress).decimals();
+            / 10 ** IERC20Like(reserveData.aTokenAddress).decimals();
 
         uint256 newSupplyCap = _calculateNewCap(
             capConfig,
@@ -239,7 +208,7 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
 
         supplyCapConfigs[asset] = capConfig;
 
-        poolConfigurator.setSupplyCap(asset, newSupplyCap);
+        IPoolConfiguratorLike(poolConfigurator).setSupplyCap(asset, newSupplyCap);
 
         emit UpdateSupplyCap(asset, currentSupplyCap, newSupplyCap);
 
@@ -247,15 +216,15 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
     }
 
     function _updateBorrowCap(address asset) internal returns (uint256) {
-        DataTypes.ReserveData memory reserveData = pool.getReserveData(asset);
+        DataTypes.ReserveData memory reserveData = IPoolLike(pool).getReserveData(asset);
         CapConfig             memory capConfig   = borrowCapConfigs[asset];
 
         uint256 currentBorrowCap = reserveData.configuration.getBorrowCap();
 
         // `stableDebt` is not in use and is always 0
         uint256 currentBorrow =
-            IERC20(reserveData.variableDebtTokenAddress).totalSupply()
-            / 10 ** IERC20Metadata(reserveData.variableDebtTokenAddress).decimals();
+            IERC20Like(reserveData.variableDebtTokenAddress).totalSupply()
+            / 10 ** IERC20Like(reserveData.variableDebtTokenAddress).decimals();
 
         uint256 newBorrowCap = _calculateNewCap(
             capConfig,
@@ -273,7 +242,7 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
 
         borrowCapConfigs[asset] = capConfig;
 
-        poolConfigurator.setBorrowCap(asset, newBorrowCap);
+        IPoolConfiguratorLike(poolConfigurator).setBorrowCap(asset, newBorrowCap);
 
         emit UpdateBorrowCap(asset, currentBorrowCap, newBorrowCap);
 

--- a/src/CapAutomator.sol
+++ b/src/CapAutomator.sol
@@ -50,6 +50,7 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         pool = IPool(
             IPoolAddressesProvider(poolAddressesProvider).getPool()
         );
+
         poolConfigurator = IPoolConfigurator(
             IPoolAddressesProvider(poolAddressesProvider).getPoolConfigurator()
         );
@@ -149,11 +150,21 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
     /*** Updater Functions                                                                      ***/
     /**********************************************************************************************/
 
-    function execSupply(address asset) external override onlyRole(UPDATE_ROLE) returns (uint256) {
+    function execSupply(address asset)
+        external
+        override
+        onlyRole(UPDATE_ROLE)
+        returns (uint256) 
+    {
         return _updateSupplyCap(asset);
     }
 
-    function execBorrow(address asset) external override onlyRole(UPDATE_ROLE) returns (uint256) {
+    function execBorrow(address asset)
+        external
+        override
+        onlyRole(UPDATE_ROLE)
+        returns (uint256) 
+    {
         return _updateBorrowCap(asset);
     }
 

--- a/src/CapAutomator.sol
+++ b/src/CapAutomator.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.13;
 
 import { AccessControlEnumerable }        from "openzeppelin-contracts/access/extensions/AccessControlEnumerable.sol";
-import { IERC20 }         from "openzeppelin-contracts/interfaces/IERC20.sol";
-import { IERC20Metadata } from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
+import { IERC20 }                         from "openzeppelin-contracts/interfaces/IERC20.sol";
+import { IERC20Metadata }                 from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
 
 import { ReserveConfiguration }   from "aave-v3-core-contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
 import { DataTypes }              from "aave-v3-core-contracts/protocol/libraries/types/DataTypes.sol";
@@ -20,9 +20,9 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
     using WadRayMath           for uint256;
 
-    /******************************************************************************************************************/
-    /*** Declarations and Constructor                                                                               ***/
-    /******************************************************************************************************************/
+    /**********************************************************************************************/
+    /*** Declarations and Constructor                                                           ***/
+    /**********************************************************************************************/
 
     struct CapConfig {
         uint48 max;              // Full tokens
@@ -40,17 +40,21 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
 
     bytes32 public constant UPDATE_ROLE = keccak256("CAP_AUTOMATOR_UPDATER");
 
-    constructor(address poolAddressesProvider, address updater) {
-        require(updater != address(0), "CapAutomator/zero-address");
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _grantRole(UPDATE_ROLE, updater);
+    constructor(address poolAddressesProvider, address admin, address updater) {
+        require(admin != address(0) && updater != address(0), "CapAutomator/zero-address");
+
+        _grantRole(DEFAULT_ADMIN_ROLE,  admin);
+        _grantRole(UPDATE_ROLE,         updater);
+        
         pool             = IPool(IPoolAddressesProvider(poolAddressesProvider).getPool());
-        poolConfigurator = IPoolConfigurator(IPoolAddressesProvider(poolAddressesProvider).getPoolConfigurator());
+        poolConfigurator = IPoolConfigurator(
+            IPoolAddressesProvider(poolAddressesProvider).getPoolConfigurator()
+        );
     }
 
-    /******************************************************************************************************************/
-    /*** Admin Functions                                                                                            ***/
-    /******************************************************************************************************************/
+    /**********************************************************************************************/
+    /*** Admin Functions                                                                        ***/
+    /**********************************************************************************************/
 
     function setSupplyCapConfig(
         address asset,
@@ -122,9 +126,9 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         emit RemoveBorrowCapConfig(asset);
     }
 
-    /******************************************************************************************************************/
-    /*** Updater Functions                                                                                          ***/
-    /******************************************************************************************************************/
+    /**********************************************************************************************/
+    /*** Updater Functions                                                                      ***/
+    /**********************************************************************************************/
 
     function execSupply(address asset) external override onlyRole(UPDATE_ROLE) returns (uint256) {
         return _updateSupplyCap(asset);
@@ -134,14 +138,16 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         return _updateBorrowCap(asset);
     }
 
-    function exec(address asset) external override onlyRole(UPDATE_ROLE) returns (uint256 newSupplyCap, uint256 newBorrowCap) {
+    function exec(
+        address asset
+    ) external override onlyRole(UPDATE_ROLE) returns (uint256 newSupplyCap, uint256 newBorrowCap) {
         newSupplyCap = _updateSupplyCap(asset);
         newBorrowCap = _updateBorrowCap(asset);
     }
 
-    /******************************************************************************************************************/
-    /*** Internal Functions                                                                                         ***/
-    /******************************************************************************************************************/
+    /**********************************************************************************************/
+    /*** Internal Functions                                                                     ***/
+    /**********************************************************************************************/
 
     function _min(uint256 a, uint256 b) internal pure returns (uint256) {
         return a <= b ? a : b;

--- a/src/CapAutomator.sol
+++ b/src/CapAutomator.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import { Ownable }        from "openzeppelin-contracts/access/Ownable.sol";
+import { AccessControlEnumerable }        from "openzeppelin-contracts/access/extensions/AccessControlEnumerable.sol";
 import { IERC20 }         from "openzeppelin-contracts/interfaces/IERC20.sol";
 import { IERC20Metadata } from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
 
-import { ReserveConfiguration }   from "aave-v3-core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
-import { DataTypes }              from "aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
-import { WadRayMath }             from "aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol";
-import { IPoolAddressesProvider } from "aave-v3-core/contracts/interfaces/IPoolAddressesProvider.sol";
-import { IPool }                  from "aave-v3-core/contracts/interfaces/IPool.sol";
-import { IPoolConfigurator }      from "aave-v3-core/contracts/interfaces/IPoolConfigurator.sol";
-import { IScaledBalanceToken }    from "aave-v3-core/contracts/interfaces/IScaledBalanceToken.sol";
+import { ReserveConfiguration }   from "aave-v3-core-contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
+import { DataTypes }              from "aave-v3-core-contracts/protocol/libraries/types/DataTypes.sol";
+import { WadRayMath }             from "aave-v3-core-contracts/protocol/libraries/math/WadRayMath.sol";
+import { IPoolAddressesProvider } from "aave-v3-core-contracts/interfaces/IPoolAddressesProvider.sol";
+import { IPool }                  from "aave-v3-core-contracts/interfaces/IPool.sol";
+import { IPoolConfigurator }      from "aave-v3-core-contracts/interfaces/IPoolConfigurator.sol";
+import { IScaledBalanceToken }    from "aave-v3-core-contracts/interfaces/IScaledBalanceToken.sol";
 
 import { ICapAutomator } from "./interfaces/ICapAutomator.sol";
 
-contract CapAutomator is ICapAutomator, Ownable {
+contract CapAutomator is ICapAutomator, AccessControlEnumerable {
 
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
     using WadRayMath           for uint256;
@@ -38,13 +38,18 @@ contract CapAutomator is ICapAutomator, Ownable {
     IPoolConfigurator public override immutable poolConfigurator;
     IPool             public override immutable pool;
 
-    constructor(address poolAddressesProvider) Ownable(msg.sender) {
+    bytes32 public constant UPDATE_ROLE = keccak256("CAP_AUTOMATOR_UPDATER");
+
+    constructor(address poolAddressesProvider, address updater) {
+        require(updater != address(0), "CapAutomator/zero-address");
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(UPDATE_ROLE, updater);
         pool             = IPool(IPoolAddressesProvider(poolAddressesProvider).getPool());
         poolConfigurator = IPoolConfigurator(IPoolAddressesProvider(poolAddressesProvider).getPoolConfigurator());
     }
 
     /******************************************************************************************************************/
-    /*** Owner Functions                                                                                            ***/
+    /*** Admin Functions                                                                                            ***/
     /******************************************************************************************************************/
 
     function setSupplyCapConfig(
@@ -52,7 +57,7 @@ contract CapAutomator is ICapAutomator, Ownable {
         uint256 max,
         uint256 gap,
         uint256 increaseCooldown
-    ) external override onlyOwner {
+    ) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         require(max > 0,                                          "CapAutomator/zero-cap");
         require(gap > 0,                                          "CapAutomator/zero-gap");
         require(max <= ReserveConfiguration.MAX_VALID_SUPPLY_CAP, "CapAutomator/invalid-cap");
@@ -79,7 +84,7 @@ contract CapAutomator is ICapAutomator, Ownable {
         uint256 max,
         uint256 gap,
         uint256 increaseCooldown
-    ) external override onlyOwner {
+    ) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         require(max > 0,                                          "CapAutomator/zero-cap");
         require(gap > 0,                                          "CapAutomator/zero-gap");
         require(max <= ReserveConfiguration.MAX_VALID_BORROW_CAP, "CapAutomator/invalid-cap");
@@ -101,7 +106,7 @@ contract CapAutomator is ICapAutomator, Ownable {
         );
     }
 
-    function removeSupplyCapConfig(address asset) external override onlyOwner {
+    function removeSupplyCapConfig(address asset) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         require(supplyCapConfigs[asset].max > 0, "CapAutomator/nonexistent-config");
 
         delete supplyCapConfigs[asset];
@@ -109,7 +114,7 @@ contract CapAutomator is ICapAutomator, Ownable {
         emit RemoveSupplyCapConfig(asset);
     }
 
-    function removeBorrowCapConfig(address asset) external override onlyOwner {
+    function removeBorrowCapConfig(address asset) external override onlyRole(DEFAULT_ADMIN_ROLE) {
         require(borrowCapConfigs[asset].max > 0, "CapAutomator/nonexistent-config");
 
         delete borrowCapConfigs[asset];
@@ -118,18 +123,18 @@ contract CapAutomator is ICapAutomator, Ownable {
     }
 
     /******************************************************************************************************************/
-    /*** Public Functions                                                                                           ***/
+    /*** Updater Functions                                                                                          ***/
     /******************************************************************************************************************/
 
-    function execSupply(address asset) external override returns (uint256) {
+    function execSupply(address asset) external override onlyRole(UPDATE_ROLE) returns (uint256) {
         return _updateSupplyCap(asset);
     }
 
-    function execBorrow(address asset) external override returns (uint256) {
+    function execBorrow(address asset) external override onlyRole(UPDATE_ROLE) returns (uint256) {
         return _updateBorrowCap(asset);
     }
 
-    function exec(address asset) external override returns (uint256 newSupplyCap, uint256 newBorrowCap) {
+    function exec(address asset) external override onlyRole(UPDATE_ROLE) returns (uint256 newSupplyCap, uint256 newBorrowCap) {
         newSupplyCap = _updateSupplyCap(asset);
         newBorrowCap = _updateBorrowCap(asset);
     }

--- a/src/CapAutomator.sol
+++ b/src/CapAutomator.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import { AccessControlEnumerable }        from "openzeppelin-contracts/access/extensions/AccessControlEnumerable.sol";
-import { IERC20 }                         from "openzeppelin-contracts/interfaces/IERC20.sol";
-import { IERC20Metadata }                 from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
+import { AccessControlEnumerable } from "openzeppelin-contracts/access/extensions/AccessControlEnumerable.sol";
+import { IERC20 }                  from "openzeppelin-contracts/interfaces/IERC20.sol";
+import { IERC20Metadata }          from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
 
 import { ReserveConfiguration }   from "aave-v3-core-contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
 import { DataTypes }              from "aave-v3-core-contracts/protocol/libraries/types/DataTypes.sol";
@@ -38,15 +38,18 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
     IPoolConfigurator public override immutable poolConfigurator;
     IPool             public override immutable pool;
 
-    bytes32 public constant UPDATE_ROLE = keccak256("CAP_AUTOMATOR_UPDATER");
+    bytes32 public constant UPDATE_ROLE = keccak256("UPDATE_ROLE");
 
-    constructor(address poolAddressesProvider, address admin, address updater) {
-        require(admin != address(0) && updater != address(0), "CapAutomator/zero-address");
+    constructor(address poolAddressesProvider, address admin, address updater)  {
+        require(admin   != address(0), "CapAutomator/invalid-admin-address");
+        require(updater != address(0), "CapAutomator/invalid-updater-address");
 
-        _grantRole(DEFAULT_ADMIN_ROLE,  admin);
-        _grantRole(UPDATE_ROLE,         updater);
-        
-        pool             = IPool(IPoolAddressesProvider(poolAddressesProvider).getPool());
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(UPDATE_ROLE,        updater);
+
+        pool = IPool(
+            IPoolAddressesProvider(poolAddressesProvider).getPool()
+        );
         poolConfigurator = IPoolConfigurator(
             IPoolAddressesProvider(poolAddressesProvider).getPoolConfigurator()
         );
@@ -61,7 +64,11 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         uint256 max,
         uint256 gap,
         uint256 increaseCooldown
-    ) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+    )
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
         require(max > 0,                                          "CapAutomator/zero-cap");
         require(gap > 0,                                          "CapAutomator/zero-gap");
         require(max <= ReserveConfiguration.MAX_VALID_SUPPLY_CAP, "CapAutomator/invalid-cap");
@@ -88,7 +95,11 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         uint256 max,
         uint256 gap,
         uint256 increaseCooldown
-    ) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+    )
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
         require(max > 0,                                          "CapAutomator/zero-cap");
         require(gap > 0,                                          "CapAutomator/zero-gap");
         require(max <= ReserveConfiguration.MAX_VALID_BORROW_CAP, "CapAutomator/invalid-cap");
@@ -110,7 +121,11 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         );
     }
 
-    function removeSupplyCapConfig(address asset) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+    function removeSupplyCapConfig(address asset)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
         require(supplyCapConfigs[asset].max > 0, "CapAutomator/nonexistent-config");
 
         delete supplyCapConfigs[asset];
@@ -118,7 +133,11 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         emit RemoveSupplyCapConfig(asset);
     }
 
-    function removeBorrowCapConfig(address asset) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+    function removeBorrowCapConfig(address asset)
+        external
+        override
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
         require(borrowCapConfigs[asset].max > 0, "CapAutomator/nonexistent-config");
 
         delete borrowCapConfigs[asset];
@@ -138,9 +157,12 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         return _updateBorrowCap(asset);
     }
 
-    function exec(
-        address asset
-    ) external override onlyRole(UPDATE_ROLE) returns (uint256 newSupplyCap, uint256 newBorrowCap) {
+    function exec(address asset)
+        external
+        override
+        onlyRole(UPDATE_ROLE)
+        returns (uint256 newSupplyCap, uint256 newBorrowCap)
+    {
         newSupplyCap = _updateSupplyCap(asset);
         newBorrowCap = _updateBorrowCap(asset);
     }

--- a/src/interfaces/Common.sol
+++ b/src/interfaces/Common.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.22;
+
+interface IERC20Like {
+
+    function decimals() external view returns (uint8);
+
+    function totalSupply() external view returns (uint256);
+
+}

--- a/src/interfaces/IAAVEV3.sol
+++ b/src/interfaces/IAAVEV3.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.22;
+
+import { DataTypes } from "../../lib/aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
+
+interface IPoolAddressesProviderLike {
+
+    function getPool() external view returns (address);
+
+    function getPoolConfigurator() external view returns (address);
+
+}
+
+interface IPoolLike {
+
+    function getReserveData(address asset) external view returns (DataTypes.ReserveData memory);
+
+}
+
+interface IPoolConfiguratorLike {
+
+    function setBorrowCap(address asset, uint256 newBorrowCap) external;
+
+    function setSupplyCap(address asset, uint256 newSupplyCap) external;
+
+}
+
+interface IScaledBalanceTokenLike {
+
+    function scaledTotalSupply() external view returns (uint256);
+
+}

--- a/src/interfaces/ICapAutomator.sol
+++ b/src/interfaces/ICapAutomator.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.0;
 
-import { IPool }             from "aave-v3-core/contracts/interfaces/IPool.sol";
-import { IPoolConfigurator } from "aave-v3-core/contracts/interfaces/IPoolConfigurator.sol";
+import { IPool }             from "aave-v3-core-contracts/interfaces/IPool.sol";
+import { IPoolConfigurator } from "aave-v3-core-contracts/interfaces/IPoolConfigurator.sol";
 
 interface ICapAutomator {
 
@@ -107,7 +107,7 @@ interface ICapAutomator {
     );
 
     /**********************************************************************************************/
-    /*** Owner Functions                                                                        ***/
+    /*** Admin Functions                                                                        ***/
     /**********************************************************************************************/
 
     /**
@@ -151,11 +151,11 @@ interface ICapAutomator {
     function removeBorrowCapConfig(address asset) external;
 
     /**********************************************************************************************/
-    /*** Public Functions                                                                       ***/
+    /*** Updater Functions                                                                      ***/
     /**********************************************************************************************/
 
     /**
-     *  @dev    A public function that updates supply cap on market of a given asset.
+     *  @dev    Updates supply cap on market of a given asset. Requires UPDATE_ROLE.
      *          The supply cap is going to be set to the value equal
      *          to the sum of current supply and the supply cap gap.
      *          The cap is only going to be increased if the required cooldown time has passed.
@@ -166,7 +166,7 @@ interface ICapAutomator {
     function execSupply(address asset) external returns (uint256 newSupplyCap);
 
     /**
-     *  @dev    A public function that updates borrow cap on market of a given asset.
+     *  @dev    Updates borrow cap on market of a given asset. Requires UPDATE_ROLE.
      *          The borrow cap is going to be set to the values equal
      *          to the sum of current borrows and the borrow cap gap.
      *          The caps is only going to be increased if the required cooldown time has passed.
@@ -177,7 +177,7 @@ interface ICapAutomator {
     function execBorrow(address asset) external returns (uint256 newBorrowCap);
 
     /**
-     *  @dev    A public function that updates supply and borrow caps on market of a given asset.
+     *  @dev    Updates supply and borrow caps on market of a given asset. Requires UPDATE_ROLE.
      *          The supply and borrow caps are going to be set to, respectively, the values equal
      *          to the sum of current supply and the supply cap gap and the sum of current borrows and the borrow cap gap.
      *          The caps are only going to be increased if the required cooldown time has passed.

--- a/src/interfaces/ICapAutomator.sol
+++ b/src/interfaces/ICapAutomator.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.22;
 
-import { IPool }             from "aave-v3-core-contracts/interfaces/IPool.sol";
-import { IPoolConfigurator } from "aave-v3-core-contracts/interfaces/IPoolConfigurator.sol";
+import { IAccessControlEnumerable } from "../../lib/openzeppelin-contracts/contracts/access/extensions/IAccessControlEnumerable.sol";
 
-interface ICapAutomator {
+interface ICapAutomator is IAccessControlEnumerable {
 
     /**********************************************************************************************/
     /*** Events                                                                                 ***/
@@ -14,19 +13,33 @@ interface ICapAutomator {
      *  @dev   Event to log the setting of a new supply cap config.
      *  @param asset            The address of the asset for which the config was set.
      *  @param max              Maximum allowed supply cap.
-     *  @param gap              A gap between the supply and the supply cap that is being maintained.
-     *  @param increaseCooldown A minimum period of time that needs to elapse between consequent cap increases.
+     *  @param gap              A gap between the supply and the supply cap that is being
+     *                          maintained.
+     *  @param increaseCooldown A minimum period of time that needs to elapse between consecutive
+     *                          cap increases.
      */
-    event SetSupplyCapConfig(address indexed asset, uint256 max, uint256 gap, uint256 increaseCooldown);
+    event SetSupplyCapConfig(
+        address indexed asset,
+        uint256         max,
+        uint256         gap,
+        uint256         increaseCooldown
+    );
 
     /**
      *  @dev   Event to log the setting of a new borrow cap config.
      *  @param asset            The address of the asset for which the config was set.
      *  @param max              Maximum allowed borrow cap.
-     *  @param gap              A gap between the borrows and the borrow cap that is being maintained.
-     *  @param increaseCooldown A minimum period of time that needs to elapse between consequent cap increases.
+     *  @param gap              A gap between the borrows and the borrow cap that is being
+     *                          maintained.
+     *  @param increaseCooldown A minimum period of time that needs to elapse between consecutive
+     *                          cap increases.
      */
-    event SetBorrowCapConfig(address indexed asset, uint256 max, uint256 gap, uint256 increaseCooldown);
+    event SetBorrowCapConfig(
+        address indexed asset,
+        uint256         max,
+        uint256         gap,
+        uint256         increaseCooldown
+    );
 
     /**
      *  @dev   Event to log the removing of a supply cap config.
@@ -64,20 +77,22 @@ interface ICapAutomator {
      *  @dev    Returns the address of the pool configurator.
      *  @return poolConfigurator The address of the pool configurator.
      */
-    function poolConfigurator() external view returns (IPoolConfigurator poolConfigurator);
+    function poolConfigurator() external view returns (address poolConfigurator);
 
     /**
      *  @dev    Returns the address of the data provider.
      *  @return pool The address of the data provider.
      */
-    function pool() external view returns (IPool pool);
+    function pool() external view returns (address pool);
 
     /**
      *  @dev    Returns current configuration for automatic supply cap management.
      *  @param  asset            The address of the asset which config is going to be returned.
      *  @return max              Maximum allowed supply cap.
-     *  @return gap              A gap between the supply and the supply cap that is being maintained.
-     *  @return increaseCooldown A minimum period of time that needs to elapse between consequent cap increases.
+     *  @return gap              A gap between the supply and the supply cap that is being
+     *                           maintained.
+     *  @return increaseCooldown A minimum period of time that needs to elapse between consecutive
+     *                           cap increases.
      *  @return lastUpdateBlock  The block of the last cap update.
      *  @return lastIncreaseTime The timestamp of the last cap increase.
      */
@@ -93,8 +108,10 @@ interface ICapAutomator {
      *  @dev    Returns current configuration for automatic borrow cap management.
      *  @param  asset            The address of the asset which config is going to be returned.
      *  @return max              Maximum allowed borrow cap.
-     *  @return gap              A gap between the borrows and the borrow cap that is being maintained.
-     *  @return increaseCooldown A minimum period of time that needs to elapse between consequent cap increases.
+     *  @return gap              A gap between the borrows and the borrow cap that is being
+     *                           maintained.
+     *  @return increaseCooldown A minimum period of time that needs to elapse between consecutive
+     *                           cap increases.
      *  @return lastUpdateBlock  The block of the last cap update.
      *  @return lastIncreaseTime The timestamp of the last cap increase.
      */
@@ -111,11 +128,13 @@ interface ICapAutomator {
     /**********************************************************************************************/
 
     /**
-     *  @dev   Function creating (or re-setting) a configuration for automatic supply cap management.
+     *  @dev   Function creating or re-setting a configuration for automatic supply cap management.
      *  @param asset            The address of the asset that is going to be managed.
      *  @param max              Maximum allowed supply cap.
-     *  @param gap              A gap between the supply and the supply cap that is being maintained.
-     *  @param increaseCooldown A minimum period of time that needs to elapse between consequent cap increases.
+     *  @param gap              A gap between the supply and the supply cap that is being
+     *                          maintained.
+     *  @param increaseCooldown A minimum period of time that needs to elapse between consecutive
+     *                          cap increases.
      */
     function setSupplyCapConfig(
         address asset,
@@ -125,11 +144,13 @@ interface ICapAutomator {
     ) external;
 
     /**
-     *  @dev   Function creating (or re-setting) a configuration for automatic borrow cap management.
+     *  @dev   Function creating or re-setting a configuration for automatic borrow cap management.
      *  @param asset            The address of the asset that is going to be managed.
      *  @param max              Maximum allowed borrow cap.
-     *  @param gap              A gap between the borrows and the borrow cap that is being maintained.
-     *  @param increaseCooldown A minimum period of time that needs to elapse between consequent cap increases.
+     *  @param gap              A gap between the borrows and the borrow cap that is being
+     *                          maintained.
+     *  @param increaseCooldown A minimum period of time that needs to elapse between consecutive
+     *                          cap increases.
      */
     function setBorrowCapConfig(
         address asset,
@@ -179,7 +200,8 @@ interface ICapAutomator {
     /**
      *  @dev    Updates supply and borrow caps on market of a given asset. Requires UPDATE_ROLE.
      *          The supply and borrow caps are going to be set to, respectively, the values equal
-     *          to the sum of current supply and the supply cap gap and the sum of current borrows and the borrow cap gap.
+     *          to the sum of current supply and the supply cap gap and the sum of current borrows
+     *          and the borrow cap gap.
      *          The caps are only going to be increased if the required cooldown time has passed.
      *          Calling this function more than once per block will not have any additional effect.
      *  @param  asset        The address of the asset which caps are going to be updated.

--- a/test/CapAutomator.t.sol
+++ b/test/CapAutomator.t.sol
@@ -1,56 +1,50 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
-import "forge-std/Test.sol";
+import { Test } from "../lib/forge-std/src/Test.sol";
 
-import { IAccessControl }           from "openzeppelin-contracts/access/IAccessControl.sol";
-import { IAccessControlEnumerable } from "openzeppelin-contracts/access/extensions/IAccessControlEnumerable.sol";
+import { IAccessControl } from "../lib/openzeppelin-contracts/contracts/access/IAccessControl.sol";
 
-import { ReserveConfiguration } from "aave-v3-core-contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
-import { DataTypes }            from "aave-v3-core-contracts/protocol/libraries/types/DataTypes.sol";
-import { IPool }                from "aave-v3-core-contracts/interfaces/IPool.sol";
-import { IPoolConfigurator }    from "aave-v3-core-contracts/interfaces/IPoolConfigurator.sol";
+import { IPoolConfigurator }    from "../lib/aave-v3-core/contracts/interfaces/IPoolConfigurator.sol";
+import { ReserveConfiguration } from "../lib/aave-v3-core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
+import { DataTypes }            from "../lib/aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
 
+import { MockPool }                  from "./mocks/MockPool.sol";
 import { MockPoolAddressesProvider } from "./mocks/MockPoolAddressesProvider.sol";
 import { MockPoolConfigurator }      from "./mocks/MockPoolConfigurator.sol";
-import { MockPool }                  from "./mocks/MockPool.sol";
-import { CapAutomatorHarness }       from "./harnesses/CapAutomatorHarness.sol";
+import { MockToken }                 from "./mocks/MockToken.sol";
+
+import { CapAutomatorHarness } from "./harnesses/CapAutomatorHarness.sol";
+
+import { ICapAutomator } from "../src/interfaces/ICapAutomator.sol";
 
 import { CapAutomator } from "../src/CapAutomator.sol";
 
 contract CapAutomatorUnitTestBase is Test {
 
-    MockPoolAddressesProvider public mockPoolAddressesProvider;
-    MockPool                  public mockPool;
-    MockPoolConfigurator      public mockPoolConfigurator;
+    MockPoolAddressesProvider internal mockPoolAddressesProvider;
+    MockPool                  internal mockPool;
+    MockPoolConfigurator      internal mockPoolConfigurator;
 
-    address public admin;
-    address public updater1;
-    address public updater2;
-    address public asset;
+    address internal admin        = makeAddr("admin");
+    address internal asset        = makeAddr("asset");
+    address internal unauthorized = makeAddr("unauthorized");
+    address internal updater1     = makeAddr("updater1");
+    address internal updater2     = makeAddr("updater2");
 
-    CapAutomator public capAutomator;
+    CapAutomator internal capAutomator;
 
-    bytes32 public DEFAULT_ADMIN_ROLE;
-    bytes32 public UPDATE_ROLE;
+    bytes32 internal DEFAULT_ADMIN_ROLE;
+    bytes32 internal UPDATE_ROLE;
 
     function setUp() public {
-        admin = makeAddr("admin");
-        asset = makeAddr("asset");
-
-        updater1 = makeAddr("updater-1");
-        updater2 = makeAddr("updater-2");
-
         mockPool                  = new MockPool();
-        mockPoolConfigurator      = new MockPoolConfigurator(mockPool);
-        mockPoolAddressesProvider = new MockPoolAddressesProvider(
-            address(mockPool),
-            address(mockPoolConfigurator)
-        );
+        mockPoolConfigurator      = new MockPoolConfigurator(address(mockPool));
+        mockPoolAddressesProvider = new MockPoolAddressesProvider(address(mockPool), address(mockPoolConfigurator));
 
         mockPool.__setSupplyCap(7_000);
 
-        mockPool.aToken().__setDecimals(18);
+        MockToken(mockPool.aToken()).__setDecimals(18);
         mockPool.__setATokenScaledTotalSupply(5_700e18);
         mockPool.__setAccruedToTreasury(50e18);
         mockPool.__setLiquidityIndex(1.2e27);
@@ -58,14 +52,10 @@ contract CapAutomatorUnitTestBase is Test {
 
         mockPool.__setBorrowCap(4_000);
 
-        mockPool.debtToken().__setDecimals(18);
+        MockToken(mockPool.debtToken()).__setDecimals(18);
         mockPool.__setTotalDebt(3_900e18);
 
-        capAutomator = new CapAutomator(
-            address(mockPoolAddressesProvider),
-            admin,
-            updater1
-        );
+        capAutomator = new CapAutomator(address(mockPoolAddressesProvider), admin, updater1);
 
         DEFAULT_ADMIN_ROLE = capAutomator.DEFAULT_ADMIN_ROLE();
         UPDATE_ROLE        = capAutomator.UPDATE_ROLE();
@@ -78,16 +68,16 @@ contract CapAutomatorUnitTestBase is Test {
 
 contract ConstructorTests is CapAutomatorUnitTestBase {
 
-    function test_constructor_setsInitialState() public {
-        assertEq(address(capAutomator.pool()),             address(mockPool));
-        assertEq(address(capAutomator.poolConfigurator()), address(mockPoolConfigurator));
+    function test_constructor_setsInitialState() external {
+        assertEq(capAutomator.pool(),             address(mockPool));
+        assertEq(capAutomator.poolConfigurator(), address(mockPoolConfigurator));
 
         assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin),    true);
         assertEq(capAutomator.hasRole(UPDATE_ROLE,        updater1), true);
         assertEq(capAutomator.hasRole(UPDATE_ROLE,        updater2), true);
     }
 
-    function test_constructor_zeroAddress() public {
+    function test_constructor_zeroAddress() external {
         vm.expectRevert("CapAutomator/invalid-admin-address");
         new CapAutomator(address(mockPoolAddressesProvider), address(0), updater1);
 
@@ -99,18 +89,19 @@ contract ConstructorTests is CapAutomatorUnitTestBase {
 
 contract GrantRoleTests is CapAutomatorUnitTestBase {
 
-    function test_grantRole_defaultAdminRole_noAuth() public {
+    function test_grantRole_defaultAdminRole_noAuth() external {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this),
+                unauthorized,
                 DEFAULT_ADMIN_ROLE
             )
         );
+        vm.prank(unauthorized);
         capAutomator.grantRole(DEFAULT_ADMIN_ROLE, makeAddr("newAdmin"));
     }
 
-    function test_grantRole_grantsDefaultAdmin() public {
+    function test_grantRole_grantsDefaultAdmin() external {
         address newAdmin = makeAddr("newAdmin");
 
         assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), false);
@@ -121,18 +112,19 @@ contract GrantRoleTests is CapAutomatorUnitTestBase {
         assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), true);
     }
 
-    function test_grantRole_updateRole_noAuth() public {
+    function test_grantRole_updateRole_noAuth() external {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this),
+                unauthorized,
                 DEFAULT_ADMIN_ROLE
             )
         );
+        vm.prank(unauthorized);
         capAutomator.grantRole(UPDATE_ROLE, makeAddr("newUpdater"));
     }
 
-    function test_grantRole_updateRole() public {
+    function test_grantRole_updateRole() external {
         address newUpdater = makeAddr("newUpdater");
 
         assertEq(capAutomator.hasRole(UPDATE_ROLE, newUpdater), false);
@@ -147,12 +139,13 @@ contract GrantRoleTests is CapAutomatorUnitTestBase {
 
 contract RenounceRoleTests is CapAutomatorUnitTestBase {
 
-    function test_renounceAdminRole_noAuth() public {
+    function test_renounceAdminRole_noAuth() external {
         vm.expectRevert(IAccessControl.AccessControlBadConfirmation.selector);
+        vm.prank(unauthorized);
         capAutomator.renounceRole(DEFAULT_ADMIN_ROLE, admin);
     }
 
-    function test_renounceAdminRole() public {
+    function test_renounceAdminRole() external {
         assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin), true);
 
         vm.prank(admin);
@@ -161,12 +154,12 @@ contract RenounceRoleTests is CapAutomatorUnitTestBase {
         assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin), false);
     }
 
-    function test_renounceUpdateRole_noAuth() public {
-        vm.expectRevert(IAccessControl.AccessControlBadConfirmation.selector); 
+    function test_renounceUpdateRole_noAuth() external {
+        vm.expectRevert(IAccessControl.AccessControlBadConfirmation.selector);
         capAutomator.renounceRole(UPDATE_ROLE, updater1);
     }
 
-    function test_renounceUpdateRole() public {
+    function test_renounceUpdateRole() external {
         assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), true);
 
         vm.prank(updater1);
@@ -179,18 +172,19 @@ contract RenounceRoleTests is CapAutomatorUnitTestBase {
 
 contract RevokeRoleTests is CapAutomatorUnitTestBase {
 
-    function test_revokeAdminRole_noAuth() public {
+    function test_revokeAdminRole_noAuth() external {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this),
+                unauthorized,
                 DEFAULT_ADMIN_ROLE
             )
         );
+        vm.prank(unauthorized);
         capAutomator.revokeRole(DEFAULT_ADMIN_ROLE, admin);
     }
 
-    function test_revokeAdminRole() public {
+    function test_revokeAdminRole() external {
         address newAdmin = makeAddr("newAdmin");
 
         vm.prank(admin);
@@ -209,18 +203,18 @@ contract RevokeRoleTests is CapAutomatorUnitTestBase {
         assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin), false);
     }
 
-    function test_revokeUpdateRole_noAuth() public {
+    function test_revokeUpdateRole_noAuth() external {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this),
+                unauthorized,
                 DEFAULT_ADMIN_ROLE
             )
         );
+        vm.prank(unauthorized);
         capAutomator.revokeRole(UPDATE_ROLE, updater1);
 
         // Self revoking role
-        vm.prank(updater1);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -228,10 +222,11 @@ contract RevokeRoleTests is CapAutomatorUnitTestBase {
                 DEFAULT_ADMIN_ROLE
             )
         );
+        vm.prank(updater1);
         capAutomator.revokeRole(UPDATE_ROLE, updater1);
     }
 
-    function test_revokeUpdateRole() public {
+    function test_revokeUpdateRole() external {
         assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), true);
 
         vm.prank(admin);
@@ -244,35 +239,35 @@ contract RevokeRoleTests is CapAutomatorUnitTestBase {
 
 contract GetRoleAdminTests is CapAutomatorUnitTestBase {
 
-    function test_getRoleAdmin_defaultAdminRole() public {
+    function test_getRoleAdmin_defaultAdminRole() external {
         assertEq(capAutomator.getRoleAdmin(DEFAULT_ADMIN_ROLE), DEFAULT_ADMIN_ROLE);
     }
 
-    function test_getRoleAdmin_updateRole() public {
+    function test_getRoleAdmin_updateRole() external {
         assertEq(capAutomator.getRoleAdmin(UPDATE_ROLE), DEFAULT_ADMIN_ROLE);
     }
 }
 
 contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
 
-    function test_getRoleMemberCount_defaultAdminRole() public {
+    function test_getRoleMemberCount_defaultAdminRole() external {
         assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
     }
 
-    function test_getRoleMemberCount_updateRole() public {
+    function test_getRoleMemberCount_updateRole() external {
         assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 2);
     }
 
-    function test_getRoleMember_defaultAdminRole() public {
+    function test_getRoleMember_defaultAdminRole() external {
         assertEq(capAutomator.getRoleMember(DEFAULT_ADMIN_ROLE, 0), admin);
     }
 
-    function test_getRoleMember_updateRole() public {
+    function test_getRoleMember_updateRole() external {
         assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0), updater1);
         assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 1), updater2);
     }
 
-    function test_getRoleMemberCount_afterGrant() public {
+    function test_getRoleMemberCount_afterGrant() external {
         address newAdmin = makeAddr("newAdmin");
 
         assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
@@ -294,7 +289,7 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
         assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 2),   newUpdater);
     }
 
-    function test_getRoleMemberCount_afterRevoke() public {
+    function test_getRoleMemberCount_afterRevoke() external {
         // Test revoking UPDATE_ROLE first (while admin still has permissions)
         assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 2);
 
@@ -313,7 +308,7 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
         assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 0);
     }
 
-    function test_getRoleMemberCount_afterRenounce() public {
+    function test_getRoleMemberCount_afterRenounce() external {
         // Test renouncing UPDATE_ROLE
         assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 2);
 
@@ -336,22 +331,15 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
 
 contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
-    function test_setSupplyCapConfig_noAuth() public {
+    function test_setSupplyCapConfig_noAuth() external {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this),
+                unauthorized,
                 DEFAULT_ADMIN_ROLE
             )
         );
-        capAutomator.setSupplyCapConfig(
-            asset,
-            10_000,
-            1_000,
-            12 hours
-        );
-
-        vm.prank(admin);
+        vm.prank(unauthorized);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -360,7 +348,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         );
     }
 
-    function test_setSupplyCapConfig_zeroCap() public {
+    function test_setSupplyCapConfig_zeroCap() external {
         vm.expectRevert("CapAutomator/zero-cap");
         vm.prank(admin);
         capAutomator.setSupplyCapConfig(
@@ -369,17 +357,9 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             0,
             12 hours
         );
-
-        vm.prank(admin);
-        capAutomator.setSupplyCapConfig(
-            asset,
-            2,
-            1,
-            12 hours
-        );
     }
 
-    function test_setSupplyCapConfig_zeroGap() public {
+    function test_setSupplyCapConfig_zeroGap() external {
         vm.expectRevert("CapAutomator/zero-gap");
         vm.prank(admin);
         capAutomator.setSupplyCapConfig(
@@ -388,17 +368,9 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             0,
             12 hours
         );
-
-        vm.prank(admin);
-        capAutomator.setSupplyCapConfig(
-            asset,
-            2,
-            1,
-            12 hours
-        );
     }
 
-    function test_setSupplyCapConfig_invalidCap() public {
+    function test_setSupplyCapConfig_maxValidSupplyCapBoundary() external {
         assertEq(ReserveConfiguration.MAX_VALID_SUPPLY_CAP, 68_719_476_735);
 
         vm.expectRevert("CapAutomator/invalid-cap");
@@ -419,13 +391,13 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         );
     }
 
-    function test_setSupplyCapConfig_invalidGap() public {
+    function test_setSupplyCapConfig_invalidGapBoundary() external {
         vm.expectRevert("CapAutomator/invalid-gap");
         vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
-            10_001,
+            10_000 + 1,
             12 hours
         );
 
@@ -438,7 +410,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         );
     }
 
-    function test_setSupplyCapConfig_invalidCooldown() public {
+    function test_setSupplyCapConfig_invalidCooldownBoundary() external {
         vm.expectRevert("CapAutomator/uint48-cast");
         vm.prank(admin);
         capAutomator.setSupplyCapConfig(
@@ -457,7 +429,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         );
     }
 
-    function test_setSupplyCapConfig() public {
+    function test_setSupplyCapConfig() external {
         (
             uint48 max,
             uint48 gap,
@@ -495,7 +467,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(lastIncreaseTime, 0);
     }
 
-    function test_setSupplyCapConfig_reconfigure() public {
+    function test_setSupplyCapConfig_reconfigure() external {
         vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
@@ -535,7 +507,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(increaseCooldown, 24 hours);
     }
 
-    function test_setSupplyCapConfig_preserveUpdateTrackers() public {
+    function test_setSupplyCapConfig_preserveUpdateTrackers() external {
         vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
@@ -555,11 +527,12 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
         vm.roll(120_000);
         vm.warp(12 hours);
+
         vm.prank(updater1);
         capAutomator.exec(asset);
 
         (
-            ,,, 
+            ,,,
             uint48 postExecUpdateBlock,
             uint48 postExecIncreaseTime
         ) = capAutomator.supplyCapConfigs(asset);
@@ -576,7 +549,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         );
 
         (
-            ,,, 
+            ,,,
             uint48 postReconfigUpdateBlock,
             uint48 postReconfigIncreaseTime
         ) = capAutomator.supplyCapConfigs(asset);
@@ -589,22 +562,15 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
 contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
-    function test_setBorrowCapConfig_noAuth() public {
+    function test_setBorrowCapConfig_noAuth() external {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this),
+                unauthorized,
                 DEFAULT_ADMIN_ROLE
             )
         );
-        capAutomator.setBorrowCapConfig(
-            asset,
-            10_000,
-            1_000,
-            12 hours
-        );
-
-        vm.prank(admin);
+        vm.prank(unauthorized);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -613,7 +579,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         );
     }
 
-    function test_setBorrowCapConfig_zeroCap() public {
+    function test_setBorrowCapConfig_zeroCap() external {
         vm.expectRevert("CapAutomator/zero-cap");
         vm.prank(admin);
         capAutomator.setBorrowCapConfig(
@@ -622,17 +588,9 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             0,
             12 hours
         );
-
-        vm.prank(admin);
-        capAutomator.setBorrowCapConfig(
-            asset,
-            2,
-            1,
-            12 hours
-        );
     }
 
-    function test_setBorrowCapConfig_zeroGap() public {
+    function test_setBorrowCapConfig_zeroGap() external {
         vm.expectRevert("CapAutomator/zero-gap");
         vm.prank(admin);
         capAutomator.setBorrowCapConfig(
@@ -641,17 +599,9 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             0,
             12 hours
         );
-
-        vm.prank(admin);
-        capAutomator.setBorrowCapConfig(
-            asset,
-            2,
-            1,
-            12 hours
-        );
     }
 
-    function test_setBorrowCapConfig_invalidCap() public {
+    function test_setBorrowCapConfig_invalidCapBoundary() external {
         assertEq(ReserveConfiguration.MAX_VALID_BORROW_CAP, 68_719_476_735);
 
         vm.expectRevert("CapAutomator/invalid-cap");
@@ -672,13 +622,13 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         );
     }
 
-    function test_setBorrowCapConfig_invalidGap() public {
+    function test_setBorrowCapConfig_invalidGapBoundary() external {
         vm.expectRevert("CapAutomator/invalid-gap");
         vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
-            10_001,
+            10_000 + 1,
             12 hours
         );
 
@@ -691,7 +641,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         );
     }
 
-    function test_setBorrowCapConfig_invalidCooldown() public {
+    function test_setBorrowCapConfig_invalidCooldownBoundary() external {
         vm.expectRevert("CapAutomator/uint48-cast");
         vm.prank(admin);
         capAutomator.setBorrowCapConfig(
@@ -710,7 +660,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         );
     }
 
-    function test_setBorrowCapConfig() public {
+    function test_setBorrowCapConfig() external {
         (
             uint48 max,
             uint48 gap,
@@ -748,7 +698,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(lastIncreaseTime, 0);
     }
 
-    function test_setBorrowCapConfig_reconfigure() public {
+    function test_setBorrowCapConfig_reconfigure() external {
         vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
@@ -788,7 +738,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(increaseCooldown, 24 hours);
     }
 
-    function test_setBorrowCapConfig_preserveUpdateTrackers() public {
+    function test_setBorrowCapConfig_preserveUpdateTrackers() external {
         vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
@@ -798,7 +748,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         );
 
         (
-            ,,, 
+            ,,,
             uint48 lastUpdateBlock,
             uint48 lastIncreaseTime
         ) = capAutomator.borrowCapConfigs(asset);
@@ -843,24 +793,25 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
 contract RemoveSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
-    function test_removeSupplyCapConfig_noAuth() public {
+    function test_removeSupplyCapConfig_noAuth() external {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this),
+                unauthorized,
                 DEFAULT_ADMIN_ROLE
             )
         );
+        vm.prank(unauthorized);
         capAutomator.removeSupplyCapConfig(asset);
     }
 
-    function test_removeSupplyCapConfig_nonexistentConfig() public {
-        vm.prank(admin);
+    function test_removeSupplyCapConfig_nonexistentConfig() external {
         vm.expectRevert("CapAutomator/nonexistent-config");
+        vm.prank(admin);
         capAutomator.removeSupplyCapConfig(asset);
     }
 
-    function test_removeSupplyCapConfig() public {
+    function test_removeSupplyCapConfig() external {
         vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
@@ -911,24 +862,25 @@ contract RemoveSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
 contract RemoveBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
-    function test_removeBorrowCapConfig_noAuth() public {
+    function test_removeBorrowCapConfig_noAuth() external {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this),
+                unauthorized,
                 DEFAULT_ADMIN_ROLE
             )
         );
+        vm.prank(unauthorized);
         capAutomator.removeBorrowCapConfig(asset);
     }
 
-    function test_removeBorrowCapConfig_nonexistentConfig() public {
-        vm.prank(admin);
+    function test_removeBorrowCapConfig_nonexistentConfig() external {
         vm.expectRevert("CapAutomator/nonexistent-config");
+        vm.prank(admin);
         capAutomator.removeBorrowCapConfig(asset);
     }
 
-    function test_removeBorrowCapConfig() public {
+    function test_removeBorrowCapConfig() external {
         vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
@@ -979,37 +931,25 @@ contract RemoveBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
 contract CalculateNewCapTests is Test {
 
-    MockPoolAddressesProvider public mockPoolAddressesProvider;
-    MockPool                  public mockPool;
-    MockPoolConfigurator      public mockPoolConfigurator;
+    MockPoolAddressesProvider internal mockPoolAddressesProvider;
+    MockPool                  internal mockPool;
+    MockPoolConfigurator      internal mockPoolConfigurator;
 
-    address public admin;
-    address public updater;
+    address internal admin = makeAddr("admin");
+    address internal updater = makeAddr("updater");
 
-    CapAutomatorHarness public capAutomator;
+    CapAutomatorHarness internal capAutomator;
 
     function setUp() public {
-
-        admin   = makeAddr("admin");
-        updater = makeAddr("updater");
-
         mockPool                  = new MockPool();
-        mockPoolConfigurator      = new MockPoolConfigurator(mockPool);
-        mockPoolAddressesProvider = new MockPoolAddressesProvider(
-            address(mockPool),
-            address(mockPoolConfigurator)
-        );
+        mockPoolConfigurator      = new MockPoolConfigurator(address(mockPool));
+        mockPoolAddressesProvider = new MockPoolAddressesProvider(address(mockPool), address(mockPoolConfigurator));
 
-        vm.startPrank(admin);
-        capAutomator = new CapAutomatorHarness(
-            address(mockPoolAddressesProvider),
-            admin,
-            updater
-        );
-        vm.stopPrank();
+        vm.prank(admin);
+        capAutomator = new CapAutomatorHarness(address(mockPoolAddressesProvider), admin, updater);
     }
 
-    function test_calculateNewCap_raiseCap() public {
+    function test_calculateNewCap_raiseCap() external {
         uint256 newCap = capAutomator._calculateNewCapExternal(
             CapAutomator.CapConfig({
                 max:              5_000,
@@ -1025,7 +965,7 @@ contract CalculateNewCapTests is Test {
         assertEq(newCap, 2_400);
     }
 
-    function test_calculateNewCap_notConfigured() public {
+    function test_calculateNewCap_notConfigured() external {
         uint256 newCap = capAutomator._calculateNewCapExternal(
             CapAutomator.CapConfig({
                 max:              0,
@@ -1041,8 +981,9 @@ contract CalculateNewCapTests is Test {
         assertEq(newCap, 2_000);
     }
 
-    function test_calculateNewCap_sameBlock() public {
+    function test_calculateNewCap_sameBlock() external {
         vm.roll(250);
+
         uint256 newCap = capAutomator._calculateNewCapExternal(
             CapAutomator.CapConfig({
                 max:              5_000,
@@ -1072,7 +1013,7 @@ contract CalculateNewCapTests is Test {
         assertEq(newCap, 2_000);
     }
 
-    function test_calculateNewCap_sameCap() public {
+    function test_calculateNewCap_sameCap() external {
         uint256 newCap = capAutomator._calculateNewCapExternal(
             CapAutomator.CapConfig({
                 max:              5_000,
@@ -1088,7 +1029,7 @@ contract CalculateNewCapTests is Test {
         assertEq(newCap, 2_000);
     }
 
-    function test_calculateNewCap_closeToMax() public {
+    function test_calculateNewCap_closeToMax() external {
         uint256 newCap = capAutomator._calculateNewCapExternal(
             CapAutomator.CapConfig({
                 max:              5_000,
@@ -1104,7 +1045,7 @@ contract CalculateNewCapTests is Test {
         assertEq(newCap, 5_000);
     }
 
-    function test_calculateNewCap_aboveMax() public {
+    function test_calculateNewCap_aboveMax() external {
         uint256 newCap = capAutomator._calculateNewCapExternal(
             CapAutomator.CapConfig({
                 max:              5_000,
@@ -1120,7 +1061,7 @@ contract CalculateNewCapTests is Test {
         assertEq(newCap, 5_000);
     }
 
-    function test_calculateNewCap_cooldown() public {
+    function test_calculateNewCap_cooldown() external {
         uint256 newCap = capAutomator._calculateNewCapExternal(
             CapAutomator.CapConfig({
                 max:              5_000,
@@ -1165,7 +1106,7 @@ contract CalculateNewCapTests is Test {
         assertEq(newCap, 2_400);
     }
 
-    function test_calculateNewCap_belowState() public {
+    function test_calculateNewCap_belowState() external {
         uint256 newCap = capAutomator._calculateNewCapExternal(
             CapAutomator.CapConfig({
                 max:              4_500,
@@ -1187,7 +1128,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
-    function test_execSupply_noAuth() public {
+    function test_execSupply_noAuth() external {
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
@@ -1199,14 +1140,14 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this), 
+                unauthorized,
                 UPDATE_ROLE
             )
         );
+        vm.prank(unauthorized);
         capAutomator.execSupply(asset);
 
         // Not even role admin can call execSupply
-        vm.prank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1214,10 +1155,11 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
                 UPDATE_ROLE
             )
         );
+        vm.prank(admin);
         capAutomator.execSupply(asset);
     }
 
-    function test_execSupply_afterRevoke() public {
+    function test_execSupply_afterRevoke() external {
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
@@ -1239,11 +1181,10 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         capAutomator.setSupplyCapConfig({
             asset:            asset,
             max:              10_000,
-            gap:              1000,
+            gap:              1_000,
             increaseCooldown: 0
         });
 
-        vm.prank(updater1);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1251,12 +1192,13 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
                 UPDATE_ROLE
             )
         );
+        vm.prank(updater1);
         capAutomator.execSupply(asset);
     }
 
-    function test_execSupply() public {
+    function test_execSupply() external {
         vm.roll(900);
-        vm.warp(900_000);
+        vm.warp(900_000 seconds);
 
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
@@ -1277,14 +1219,14 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
             1
         );
+        vm.prank(updater1);
         uint256 newCap = capAutomator.execSupply(asset);
-        
+
         assertEq(newCap, 7_400);
 
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
@@ -1301,9 +1243,9 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastIncreaseTimeAfter, 900_000);
     }
 
-    function test_execSupply_multipleUpdaters() public {
+    function test_execSupply_multipleUpdaters() external {
         vm.roll(900);
-        vm.warp(900_000);
+        vm.warp(900_000 seconds);
 
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
@@ -1324,14 +1266,14 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
             1
         );
+        vm.prank(updater1);
         uint256 newCap = capAutomator.execSupply(asset);
-        
+
         assertEq(newCap, 7_400);
 
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
@@ -1347,14 +1289,14 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockAfter,  900);
         assertEq(lastIncreaseTimeAfter, 900_000);
 
-        vm.roll(1800);
-        vm.warp(1800_000);
+        vm.roll(1_800);
+        vm.warp(1_800_000 seconds);
 
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
             max:              10_000,
-            gap:              1000,
+            gap:              1_000,
             increaseCooldown: 0
         });
 
@@ -1368,13 +1310,13 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(lastUpdateBlockBefore,  900);
         assertEq(lastIncreaseTimeBefore, 900_000);
-        
-        vm.prank(updater2);
+
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_900))),
             1
         );
+        vm.prank(updater2);
         newCap = capAutomator.execSupply(asset);
 
         assertEq(newCap, 7_900);
@@ -1393,12 +1335,11 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastIncreaseTimeAfter, 1800_000);
     }
 
-
-    function test_execSupply_differentDecimals() public {
+    function test_execSupply_differentDecimals() external {
         vm.roll(300);
-        vm.warp(300_000);
+        vm.warp(300_000 seconds);
 
-        mockPool.aToken().__setDecimals(6);
+        MockToken(mockPool.aToken()).__setDecimals(6);
         mockPool.__setATokenScaledTotalSupply(4_500e6);
         mockPool.__setAccruedToTreasury(100e6);
         mockPool.__setLiquidityIndex(1.5e27);
@@ -1421,13 +1362,13 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
-        
-        vm.prank(updater1);
+
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
             1
         );
+        vm.prank(updater1);
         uint256 newCap = capAutomator.execSupply(asset);
 
         assertEq(newCap, 7_400);
@@ -1446,7 +1387,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastIncreaseTimeAfter, 300_000);
     }
 
-    function test_execSupply_sameCap() public {
+    function test_execSupply_sameCap() external {
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
@@ -1457,12 +1398,12 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_000))),
             0
         );
+        vm.prank(updater1);
         uint256 newCap = capAutomator.execSupply(asset);
 
         assertEq(newCap, 7_000);
@@ -1472,7 +1413,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
     }
 
-    function test_execSupply_belowState() public {
+    function test_execSupply_belowState() external {
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
@@ -1483,12 +1424,12 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(2_000))),
             1
         );
+        vm.prank(updater1);
         uint256 newCap = capAutomator.execSupply(asset);
 
         assertEq(newCap, 2_000);
@@ -1502,7 +1443,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
-    function test_execBorrow_noAuth() public {
+    function test_execBorrow_noAuth() external {
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
@@ -1514,10 +1455,11 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this),
+                unauthorized,
                 UPDATE_ROLE
             )
         );
+        vm.prank(unauthorized);
         capAutomator.execBorrow(asset);
 
         // Not even role admin can call execBorrow
@@ -1532,7 +1474,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         capAutomator.execBorrow(asset);
     }
 
-    function test_execBorrow_afterRevoke() public {
+    function test_execBorrow_afterRevoke() external {
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
@@ -1558,7 +1500,6 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        vm.prank(updater1);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1566,12 +1507,13 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
                 UPDATE_ROLE
             )
         );
+        vm.prank(updater1);
         capAutomator.execBorrow(asset);
     }
 
-    function test_execBorrow() public {
+    function test_execBorrow() external {
         vm.roll(100);
-        vm.warp(100_000);
+        vm.warp(100_000 seconds);
 
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
@@ -1592,12 +1534,12 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
             1
         );
+        vm.prank(updater1);
         uint256 newCap = capAutomator.execBorrow(asset);
 
         assertEq(newCap, 4_400); // totalDebt + gap = 3900 + 500 = 4400
@@ -1614,9 +1556,9 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastIncreaseTimeAfter, 100_000);
     }
 
-    function test_execBorrow_multipleUpdaters() public {
+    function test_execBorrow_multipleUpdaters() external {
         vm.roll(100);
-        vm.warp(100_000);
+        vm.warp(100_000 seconds);
 
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
@@ -1637,17 +1579,17 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.prank(updater1);  
-        vm.expectCall(  
-            address(mockPoolConfigurator),  
-            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),  
-            1  
-        );  
-        uint256 newCap = capAutomator.execBorrow(asset);  
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
+            1
+        );
+        vm.prank(updater1);
+        uint256 newCap = capAutomator.execBorrow(asset);
 
-        assertEq(newCap, 4_400);  // totalDebt + gap = 3900 + 500 = 4400  
-        
-        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);  
+        assertEq(newCap, 4_400);  // totalDebt + gap = 3900 + 500 = 4400
+
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
         (
             ,,,
@@ -1659,13 +1601,13 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastIncreaseTimeAfter, 100_000);
 
         vm.roll(200);
-        vm.warp(200_000);
+        vm.warp(200_000 seconds);
 
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
             max:              10_000,
-            gap:              1000,
+            gap:              1_000,
             increaseCooldown: 0
         });
 
@@ -1680,12 +1622,12 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  100);
         assertEq(lastIncreaseTimeBefore, 100_000);
 
-        vm.prank(updater2);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_900))),
             1
         );
+        vm.prank(updater2);
         newCap = capAutomator.execBorrow(asset);
 
         assertEq(newCap, 4_900); // totalDebt + gap = 3900 + 1000 = 4900
@@ -1702,11 +1644,11 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastIncreaseTimeAfter, 200_000);
     }
 
-    function test_execBorrow_differentDecimals() public {
+    function test_execBorrow_differentDecimals() external {
         vm.roll(200);
-        vm.warp(200_000);
+        vm.warp(200_000 seconds);
 
-        mockPool.debtToken().__setDecimals(6);
+        MockToken(mockPool.debtToken()).__setDecimals(6);
         mockPool.__setTotalDebt(3_900e6);
 
         vm.prank(admin);
@@ -1728,12 +1670,12 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
             1
         );
+        vm.prank(updater1);
         uint256 newCap = capAutomator.execBorrow(asset);
 
         assertEq(newCap, 4_400); // totalDebt + gap = 3900 + 500 = 4400
@@ -1750,7 +1692,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastIncreaseTimeAfter, 200_000);
     }
 
-    function test_execBorrow_sameCap() public {
+    function test_execBorrow_sameCap() external {
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
@@ -1761,12 +1703,12 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))), 
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))),
             0
         );
+        vm.prank(updater1);
         uint256 newCap = capAutomator.execBorrow(asset);
 
         assertEq(newCap, 4_000); // totalDebt + gap = 3900 + 100 = 4000
@@ -1774,7 +1716,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
     }
 
-    function test_execBorrow_belowState() public {
+    function test_execBorrow_belowState() external {
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
@@ -1784,13 +1726,13 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         });
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
-        
-        vm.prank(updater1);
+
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(1_000))),
             1
         );
+        vm.prank(updater1);
         uint256 newCap = capAutomator.execBorrow(asset);
 
         assertEq(newCap, 1_000);
@@ -1804,7 +1746,7 @@ contract ExecTests is CapAutomatorUnitTestBase {
 
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
-    function test_exec_noAuth() public {
+    function test_exec_noAuth() external {
         mockPool.__setSupplyCap(7_000);
         mockPool.__setBorrowCap(4_000);
 
@@ -1826,10 +1768,11 @@ contract ExecTests is CapAutomatorUnitTestBase {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(this),
+                unauthorized,
                 UPDATE_ROLE
             )
         );
+        vm.prank(unauthorized);
         capAutomator.exec(asset);
 
         // Not even role admin can call exec
@@ -1844,7 +1787,7 @@ contract ExecTests is CapAutomatorUnitTestBase {
         capAutomator.exec(asset);
     }
 
-    function test_exec_afterRevoke() public {
+    function test_exec_afterRevoke() external {
         mockPool.__setSupplyCap(7_000);
         mockPool.__setBorrowCap(4_000);
 
@@ -1869,7 +1812,7 @@ contract ExecTests is CapAutomatorUnitTestBase {
         // Revoke UPDATE_ROLE from updater1
         vm.prank(admin);
         capAutomator.revokeRole(UPDATE_ROLE, updater1);
-        
+
         assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
 
         vm.startPrank(admin);
@@ -1886,8 +1829,7 @@ contract ExecTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
         vm.stopPrank();
-        
-        vm.prank(updater1);
+
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1895,10 +1837,11 @@ contract ExecTests is CapAutomatorUnitTestBase {
                 UPDATE_ROLE
             )
         );
+        vm.prank(updater1);
         capAutomator.exec(asset);
     }
 
-    function test_exec() public {
+    function test_exec() external {
         mockPool.__setSupplyCap(7_000);
         mockPool.__setBorrowCap(4_000);
 
@@ -1931,10 +1874,10 @@ contract ExecTests is CapAutomatorUnitTestBase {
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))),
             1
         );
-        
+
         vm.prank(updater1);
         ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
-        
+
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
         // = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
         assertEq(newSupplyCap, 7_300);
@@ -1944,7 +1887,7 @@ contract ExecTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
     }
 
-    function test_exec_multipleUpdaters() public {
+    function test_exec_multipleUpdaters() external {
         mockPool.__setSupplyCap(7_000);
         mockPool.__setBorrowCap(4_000);
 
@@ -1971,13 +1914,13 @@ contract ExecTests is CapAutomatorUnitTestBase {
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))),
             1
         );
-        
+
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))),
             1
         );
-        
+
         vm.prank(updater1);
         ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
 
@@ -1989,8 +1932,8 @@ contract ExecTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_300);
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
 
-        vm.roll(1000);
-        vm.warp(1000_000);
+        vm.roll(1_000);
+        vm.warp(1_000_000 seconds);
 
         vm.startPrank(admin);
         capAutomator.setSupplyCapConfig({
@@ -2015,7 +1958,7 @@ contract ExecTests is CapAutomatorUnitTestBase {
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_100))),
             1
         );
-       
+
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))),
@@ -2038,83 +1981,64 @@ contract ExecTests is CapAutomatorUnitTestBase {
 
 contract EventTests is CapAutomatorUnitTestBase {
 
-    // AccessControl events
-    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
-    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
-
-    // CapAutomator events
-    event SetSupplyCapConfig(
-        address indexed asset, 
-        uint256 max, 
-        uint256 gap, 
-        uint256 increaseCooldown
-    );
-    event SetBorrowCapConfig(
-        address indexed asset,
-        uint256 max,
-        uint256 gap,
-        uint256 increaseCooldown
-    );
-
-    event RemoveSupplyCapConfig(address indexed asset);
-    event RemoveBorrowCapConfig(address indexed asset);
-
-    event UpdateSupplyCap(address indexed asset, uint256 oldSupplyCap, uint256 newSupplyCap);
-    event UpdateBorrowCap(address indexed asset, uint256 oldBorrowCap, uint256 newBorrowCap);
-
-    function test_RoleGranted_defaultAdminRole() public {
+    function test_RoleGranted_defaultAdminRole() external {
         address newAdmin = makeAddr("newAdmin");
 
-        vm.prank(admin);
         vm.expectEmit(address(capAutomator));
-        emit RoleGranted(DEFAULT_ADMIN_ROLE, newAdmin, admin);
+        emit IAccessControl.RoleGranted(DEFAULT_ADMIN_ROLE, newAdmin, admin);
+
+        vm.prank(admin);
         capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
     }
 
-    function test_RoleGranted_updateRole() public {
+    function test_RoleGranted_updateRole() external {
         address newUpdater = makeAddr("newUpdater");
 
-        vm.prank(admin);
         vm.expectEmit(address(capAutomator));
-        emit RoleGranted(UPDATE_ROLE, newUpdater, admin);
+        emit IAccessControl.RoleGranted(UPDATE_ROLE, newUpdater, admin);
+
+        vm.prank(admin);
         capAutomator.grantRole(UPDATE_ROLE, newUpdater);
     }
 
-    function test_RoleRevoked_defaultAdminRole() public {
+    function test_RoleRevoked_defaultAdminRole() external {
         address newAdmin = makeAddr("newAdmin");
 
-        vm.startPrank(admin);
+        vm.prank(admin);
         capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
 
         vm.expectEmit(address(capAutomator));
-        emit RoleRevoked(DEFAULT_ADMIN_ROLE, newAdmin, admin);
+        emit IAccessControl.RoleRevoked(DEFAULT_ADMIN_ROLE, newAdmin, admin);
+
+        vm.prank(admin);
         capAutomator.revokeRole(DEFAULT_ADMIN_ROLE, newAdmin);
-        vm.stopPrank();
     }
 
-    function test_RoleRevoked_updateRole() public {
-        vm.prank(admin);
+    function test_RoleRevoked_updateRole() external {
         vm.expectEmit(address(capAutomator));
-        emit RoleRevoked(UPDATE_ROLE, updater1, admin);
+        emit IAccessControl.RoleRevoked(UPDATE_ROLE, updater1, admin);
+
+        vm.prank(admin);
         capAutomator.revokeRole(UPDATE_ROLE, updater1);
     }
 
-    function test_RoleRevoked_renounce() public {
-        vm.prank(updater1);
+    function test_RoleRevoked_renounce() external {
         vm.expectEmit(address(capAutomator));
-        emit RoleRevoked(UPDATE_ROLE, updater1, updater1);
+        emit IAccessControl.RoleRevoked(UPDATE_ROLE, updater1, updater1);
+
+        vm.prank(updater1);
         capAutomator.renounceRole(UPDATE_ROLE, updater1);
     }
 
-    function test_SetSupplyCapConfig() public {
-        vm.prank(admin);
-        vm.expectEmit(address(capAutomator));
-        emit SetSupplyCapConfig(
+    function test_SetSupplyCapConfig() external {
+        emit ICapAutomator.SetSupplyCapConfig(
             asset,
             20_000,
             2_000,
             24 hours
         );
+
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             20_000,
@@ -2123,15 +2047,16 @@ contract EventTests is CapAutomatorUnitTestBase {
         );
     }
 
-    function test_SetBorrowCapConfig() public {
-        vm.prank(admin);
+    function test_SetBorrowCapConfig() external {
         vm.expectEmit(address(capAutomator));
-        emit SetBorrowCapConfig(
+        emit ICapAutomator.SetBorrowCapConfig(
             asset,
             10_000,
             1_000,
             12 hours
         );
+
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -2140,35 +2065,39 @@ contract EventTests is CapAutomatorUnitTestBase {
         );
     }
 
-    function test_RemoveSupplyCapConfig() public {
-        vm.startPrank(admin);
+    function test_RemoveSupplyCapConfig() external {
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             20_000,
             2_000,
             24 hours
         );
+
         vm.expectEmit(address(capAutomator));
-        emit RemoveSupplyCapConfig(asset);
+        emit ICapAutomator.RemoveSupplyCapConfig(asset);
+
+        vm.prank(admin);
         capAutomator.removeSupplyCapConfig(asset);
-        vm.stopPrank();
     }
 
-    function test_RemoveBorrowCapConfig() public {
-        vm.startPrank(admin);
+    function test_RemoveBorrowCapConfig() external {
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
             1_000,
             12 hours
         );
+
         vm.expectEmit(address(capAutomator));
-        emit RemoveBorrowCapConfig(asset);
+        emit ICapAutomator.RemoveBorrowCapConfig(asset);
+
+        vm.prank(admin);
         capAutomator.removeBorrowCapConfig(asset);
-        vm.stopPrank();
     }
 
-    function test_UpdateSupplyCap() public {
+    function test_UpdateSupplyCap() external {
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
@@ -2177,15 +2106,16 @@ contract EventTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        vm.prank(updater1);
-        vm.expectEmit(address(capAutomator));
-        emit UpdateSupplyCap(asset, 7_000, 7_300);
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
         // = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
+        vm.expectEmit(address(capAutomator));
+        emit ICapAutomator.UpdateSupplyCap(asset, 7_000, 7_300);
+
+        vm.prank(updater1);
         capAutomator.execSupply(asset);
     }
 
-    function test_UpdateBorrowCap() public {
+    function test_UpdateBorrowCap() external {
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
@@ -2194,9 +2124,10 @@ contract EventTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        vm.prank(updater1);
         vm.expectEmit(address(capAutomator));
-        emit UpdateBorrowCap(asset, 4_000, 4_200); // totalDebt + gap = 3900 + 300 = 4200
+        emit ICapAutomator.UpdateBorrowCap(asset, 4_000, 4_200); // totalDebt + gap = 3900 + 300 = 4200
+
+        vm.prank(updater1);
         capAutomator.exec(asset);
     }
 

--- a/test/CapAutomator.t.sol
+++ b/test/CapAutomator.t.sol
@@ -214,7 +214,7 @@ contract RevokeRoleTests is CapAutomatorUnitTestBase {
         vm.prank(unauthorized);
         capAutomator.revokeRole(UPDATE_ROLE, updater1);
 
-        // Self revoking role
+        // Can't revoke role on self, only role admin can revoke the role
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1129,14 +1129,6 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
     function test_execSupply_noAuth() external {
-        vm.prank(admin);
-        capAutomator.setSupplyCapConfig({
-            asset:            asset,
-            max:              10_000,
-            gap:              500,
-            increaseCooldown: 0
-        });
-
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1147,7 +1139,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         vm.prank(unauthorized);
         capAutomator.execSupply(asset);
 
-        // Not even role admin can call execSupply
+        // Not even
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1156,43 +1148,6 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             )
         );
         vm.prank(admin);
-        capAutomator.execSupply(asset);
-    }
-
-    function test_execSupply_afterRevoke() external {
-        vm.prank(admin);
-        capAutomator.setSupplyCapConfig({
-            asset:            asset,
-            max:              10_000,
-            gap:              500,
-            increaseCooldown: 0
-        });
-
-        vm.prank(updater1);
-        capAutomator.execSupply(asset);
-
-        // Revoke UPDATE_ROLE from updater1
-        vm.prank(admin);
-        capAutomator.revokeRole(UPDATE_ROLE, updater1);
-
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
-
-        vm.prank(admin);
-        capAutomator.setSupplyCapConfig({
-            asset:            asset,
-            max:              10_000,
-            gap:              1_000,
-            increaseCooldown: 0
-        });
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector,
-                updater1,
-                UPDATE_ROLE
-            )
-        );
-        vm.prank(updater1);
         capAutomator.execSupply(asset);
     }
 
@@ -1444,14 +1399,6 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
     function test_execBorrow_noAuth() external {
-        vm.prank(admin);
-        capAutomator.setBorrowCapConfig({
-            asset:            asset,
-            max:              10_000,
-            gap:              500,
-            increaseCooldown: 0
-        });
-
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1462,7 +1409,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         vm.prank(unauthorized);
         capAutomator.execBorrow(asset);
 
-        // Not even role admin can call execBorrow
+        // Not even
         vm.prank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1471,43 +1418,6 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
                 UPDATE_ROLE
             )
         );
-        capAutomator.execBorrow(asset);
-    }
-
-    function test_execBorrow_afterRevoke() external {
-        vm.prank(admin);
-        capAutomator.setBorrowCapConfig({
-            asset:            asset,
-            max:              10_000,
-            gap:              500,
-            increaseCooldown: 0
-        });
-
-        vm.prank(updater1);
-        capAutomator.execBorrow(asset);
-
-        // Revoke UPDATE_ROLE from updater1
-        vm.prank(admin);
-        capAutomator.revokeRole(UPDATE_ROLE, updater1);
-
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
-
-        vm.prank(admin);
-        capAutomator.setBorrowCapConfig({
-            asset:            asset,
-            max:              10_000,
-            gap:              100,
-            increaseCooldown: 0
-        });
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector,
-                updater1,
-                UPDATE_ROLE
-            )
-        );
-        vm.prank(updater1);
         capAutomator.execBorrow(asset);
     }
 
@@ -1747,24 +1657,6 @@ contract ExecTests is CapAutomatorUnitTestBase {
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
     function test_exec_noAuth() external {
-        mockPool.__setSupplyCap(7_000);
-        mockPool.__setBorrowCap(4_000);
-
-        vm.startPrank(admin);
-        capAutomator.setSupplyCapConfig({
-            asset:            asset,
-            max:              10_000,
-            gap:              400,
-            increaseCooldown: 0
-        });
-        capAutomator.setBorrowCapConfig({
-            asset:            asset,
-            max:              8_000,
-            gap:              300,
-            increaseCooldown: 0
-        });
-        vm.stopPrank();
-
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1775,7 +1667,7 @@ contract ExecTests is CapAutomatorUnitTestBase {
         vm.prank(unauthorized);
         capAutomator.exec(asset);
 
-        // Not even role admin can call exec
+        // Not even
         vm.prank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1784,60 +1676,6 @@ contract ExecTests is CapAutomatorUnitTestBase {
                 UPDATE_ROLE
             )
         );
-        capAutomator.exec(asset);
-    }
-
-    function test_exec_afterRevoke() external {
-        mockPool.__setSupplyCap(7_000);
-        mockPool.__setBorrowCap(4_000);
-
-        vm.startPrank(admin);
-        capAutomator.setSupplyCapConfig({
-            asset:            asset,
-            max:              10_000,
-            gap:              400,
-            increaseCooldown: 0
-        });
-        capAutomator.setBorrowCapConfig({
-            asset:            asset,
-            max:              8_000,
-            gap:              300,
-            increaseCooldown: 0
-        });
-        vm.stopPrank();
-
-        vm.prank(updater1);
-        capAutomator.exec(asset);
-
-        // Revoke UPDATE_ROLE from updater1
-        vm.prank(admin);
-        capAutomator.revokeRole(UPDATE_ROLE, updater1);
-
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
-
-        vm.startPrank(admin);
-        capAutomator.setSupplyCapConfig({
-            asset:            asset,
-            max:              10_000,
-            gap:              200,
-            increaseCooldown: 0
-        });
-        capAutomator.setBorrowCapConfig({
-            asset:            asset,
-            max:              8_000,
-            gap:              100,
-            increaseCooldown: 0
-        });
-        vm.stopPrank();
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector,
-                updater1,
-                UPDATE_ROLE
-            )
-        );
-        vm.prank(updater1);
         capAutomator.exec(asset);
     }
 

--- a/test/CapAutomator.t.sol
+++ b/test/CapAutomator.t.sol
@@ -24,9 +24,10 @@ contract CapAutomatorUnitTestBase is Test {
     MockPool                  public mockPool;
     MockPoolConfigurator      public mockPoolConfigurator;
 
-    address   public admin;
-    address[] public updaters;
-    address   public asset;
+    address public admin;
+    address public updater1;
+    address public updater2;
+    address public asset;
 
     CapAutomator public capAutomator;
 
@@ -34,16 +35,17 @@ contract CapAutomatorUnitTestBase is Test {
     bytes32 public UPDATE_ROLE;
 
     function setUp() public {
-        admin   = makeAddr("admin");
-        asset   = makeAddr("asset");
+        admin = makeAddr("admin");
+        asset = makeAddr("asset");
 
-        updaters.push(makeAddr("updater-1"));
-        updaters.push(makeAddr("updater-2"));
+        updater1 = makeAddr("updater-1");
+        updater2 = makeAddr("updater-2");
 
         mockPool                  = new MockPool();
         mockPoolConfigurator      = new MockPoolConfigurator(mockPool);
         mockPoolAddressesProvider = new MockPoolAddressesProvider(
-            address(mockPool), address(mockPoolConfigurator)
+            address(mockPool),
+            address(mockPoolConfigurator)
         );
 
         mockPool.__setSupplyCap(7_000);
@@ -59,14 +61,17 @@ contract CapAutomatorUnitTestBase is Test {
         mockPool.debtToken().__setDecimals(18);
         mockPool.__setTotalDebt(3_900e18);
 
-        vm.startPrank(admin);
-        capAutomator = new CapAutomator(address(mockPoolAddressesProvider), admin, updaters[0]);
+        capAutomator = new CapAutomator(
+            address(mockPoolAddressesProvider),
+            admin,
+            updater1
+        );
 
-        DEFAULT_ADMIN_ROLE  = capAutomator.DEFAULT_ADMIN_ROLE();
-        UPDATE_ROLE         = capAutomator.UPDATE_ROLE();
+        DEFAULT_ADMIN_ROLE = capAutomator.DEFAULT_ADMIN_ROLE();
+        UPDATE_ROLE        = capAutomator.UPDATE_ROLE();
 
-        capAutomator.grantRole(UPDATE_ROLE, updaters[1]);
-        vm.stopPrank();
+        vm.prank(admin);
+        capAutomator.grantRole(UPDATE_ROLE, updater2);
     }
 
 }
@@ -77,19 +82,19 @@ contract ConstructorTests is CapAutomatorUnitTestBase {
         assertEq(address(capAutomator.pool()),             address(mockPool));
         assertEq(address(capAutomator.poolConfigurator()), address(mockPoolConfigurator));
 
-        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin),   true);
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]),    true);
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[1]),    true);
+        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin), true);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1),     true);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater2),     true);
     }
 
     function test_constructor_zeroAddress() public {
-        vm.expectRevert("CapAutomator/zero-address");
-        new CapAutomator(address(mockPoolAddressesProvider), address(0), updaters[0]);
+        vm.expectRevert("CapAutomator/invalid-admin-address");
+        new CapAutomator(address(mockPoolAddressesProvider), address(0), updater1);
 
-        vm.expectRevert("CapAutomator/zero-address");
+        vm.expectRevert("CapAutomator/invalid-updater-address");
         new CapAutomator(address(mockPoolAddressesProvider), admin, address(0));
 
-        vm.expectRevert("CapAutomator/zero-address");
+        vm.expectRevert("CapAutomator/invalid-admin-address");
         new CapAutomator(address(mockPoolAddressesProvider), address(0), address(0));
     }
 
@@ -104,8 +109,8 @@ contract GrantRoleTests is CapAutomatorUnitTestBase {
         vm.prank(notAdmin);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, 
-                notAdmin, 
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                notAdmin,
                 DEFAULT_ADMIN_ROLE
             )
         );
@@ -124,14 +129,14 @@ contract GrantRoleTests is CapAutomatorUnitTestBase {
     }
 
     function test_grantRole_updateRole_noAuth() public {
-        address notAdmin = makeAddr("notAdmin");
+        address notAdmin   = makeAddr("notAdmin");
         address newUpdater = makeAddr("newUpdater");
 
         vm.prank(notAdmin);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, 
-                notAdmin, 
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                notAdmin,
                 DEFAULT_ADMIN_ROLE
             )
         );
@@ -153,7 +158,7 @@ contract GrantRoleTests is CapAutomatorUnitTestBase {
 
 contract RenounceRoleTests is CapAutomatorUnitTestBase {
 
-    function test_renounceAdminRole_badConfirmation() public {
+    function test_renounceAdminRole_noAuth() public {
         vm.prank(makeAddr("notAdmin"));
         vm.expectRevert(IAccessControl.AccessControlBadConfirmation.selector);
         capAutomator.renounceRole(DEFAULT_ADMIN_ROLE, admin);
@@ -168,19 +173,19 @@ contract RenounceRoleTests is CapAutomatorUnitTestBase {
         assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin), false);
     }
 
-    function test_renounceUpdateRole_badConfirmation() public {
+    function test_renounceUpdateRole_noAuth() public {
         vm.prank(makeAddr("notUpdater"));
-        vm.expectRevert(IAccessControl.AccessControlBadConfirmation.selector);
-        capAutomator.renounceRole(UPDATE_ROLE, updaters[0]);
+        vm.expectRevert(IAccessControl.AccessControlBadConfirmation.selector); 
+        capAutomator.renounceRole(UPDATE_ROLE, updater1);
     }
 
     function test_renounceUpdateRole() public {
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), true);
 
-        vm.prank(updaters[0]);
-        capAutomator.renounceRole(UPDATE_ROLE, updaters[0]);
+        vm.prank(updater1);
+        capAutomator.renounceRole(UPDATE_ROLE, updater1);
 
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), false);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
     }
 
 }
@@ -194,7 +199,7 @@ contract RevokeRoleTests is CapAutomatorUnitTestBase {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                notAdmin, 
+                notAdmin,
                 DEFAULT_ADMIN_ROLE
             )
         );
@@ -222,37 +227,37 @@ contract RevokeRoleTests is CapAutomatorUnitTestBase {
     function test_revokeUpdateRole_noAuth() public {
         address notAdmin = makeAddr("notAdmin");
 
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), true);
 
         vm.prank(notAdmin);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, 
-                notAdmin, 
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                notAdmin,
                 DEFAULT_ADMIN_ROLE
             )
         );
-        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+        capAutomator.revokeRole(UPDATE_ROLE, updater1);
 
         // self revoking role
-        vm.prank(updaters[0]);
+        vm.prank(updater1);
         vm.expectRevert(
             abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, 
-                updaters[0], 
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                updater1,
                 DEFAULT_ADMIN_ROLE
             )
         );
-        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+        capAutomator.revokeRole(UPDATE_ROLE, updater1);
     }
 
     function test_revokeUpdateRole() public {
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), true);
 
         vm.prank(admin);
-        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+        capAutomator.revokeRole(UPDATE_ROLE, updater1);
 
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), false);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
     }
 
 }
@@ -283,8 +288,8 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
     }
 
     function test_getRoleMember_updateRole() public {
-        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0), updaters[0]);
-        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 1), updaters[1]);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0), updater1);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 1), updater2);
     }
 
     function test_getRoleMemberCount_afterGrant() public {
@@ -295,8 +300,8 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
         vm.prank(admin);
         capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
 
-        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE),   2);
-        assertEq(capAutomator.getRoleMember(DEFAULT_ADMIN_ROLE, 1),     newAdmin);
+        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 2);
+        assertEq(capAutomator.getRoleMember(DEFAULT_ADMIN_ROLE, 1),   newAdmin);
 
         address newUpdater = makeAddr("newUpdater");
 
@@ -305,8 +310,8 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
         vm.prank(admin);
         capAutomator.grantRole(UPDATE_ROLE, newUpdater);
 
-        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE),  3);
-        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 2),    newUpdater);
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 3);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 2),   newUpdater);
     }
 
     function test_getRoleMemberCount_afterRevoke() public {
@@ -314,10 +319,10 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
         assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 2);
 
         vm.prank(admin);
-        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+        capAutomator.revokeRole(UPDATE_ROLE, updater1);
 
-        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE),  1);
-        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0),    updaters[1]);
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 1);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0),   updater2);
 
         // Test revoking DEFAULT_ADMIN_ROLE
         assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
@@ -332,11 +337,11 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
         // Test renouncing UPDATE_ROLE
         assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 2);
 
-        vm.prank(updaters[0]);
-        capAutomator.renounceRole(UPDATE_ROLE, updaters[0]);
+        vm.prank(updater1);
+        capAutomator.renounceRole(UPDATE_ROLE, updater1);
 
-        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE),  1);
-        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0),    updaters[1]);
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 1);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0),   updater2);
 
         // Test renouncing DEFAULT_ADMIN_ROLE
         assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
@@ -355,8 +360,8 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         vm.prank(makeAddr("notAdmin"));
         vm.expectRevert(
             abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector, 
-                makeAddr("notAdmin"), 
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                makeAddr("notAdmin"),
                 DEFAULT_ADMIN_ROLE
             )
         );
@@ -560,8 +565,8 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        ( 
-            ,,, 
+        (
+            ,,,
             uint48 lastUpdateBlock,
             uint48 lastIncreaseTime
         ) = capAutomator.supplyCapConfigs(asset);
@@ -571,10 +576,10 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
         vm.roll(120_000);
         vm.warp(12 hours);
-        vm.prank(updaters[0]);
+        vm.prank(updater1);
         capAutomator.exec(asset);
 
-        ( 
+        (
             ,,, 
             uint48 postExecUpdateBlock,
             uint48 postExecIncreaseTime
@@ -591,7 +596,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             24 hours
         );
 
-        ( 
+        (
             ,,, 
             uint48 postReconfigUpdateBlock,
             uint48 postReconfigIncreaseTime
@@ -814,7 +819,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        ( 
+        (
             ,,, 
             uint48 lastUpdateBlock,
             uint48 lastIncreaseTime
@@ -825,10 +830,11 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
         vm.roll(600);
         vm.warp(12 hours);
-        vm.prank(updaters[0]);
+
+        vm.prank(updater1);
         capAutomator.exec(asset);
 
-        ( 
+        (
             ,,,
             uint48 postExecUpdateBlock,
             uint48 postExecIncreaseTime
@@ -845,7 +851,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             24 hours
         );
 
-        ( 
+        (
             ,,,
             uint48 postReconfigUpdateBlock,
             uint48 postReconfigIncreaseTime
@@ -890,7 +896,7 @@ contract RemoveSupplyCapConfigTests is CapAutomatorUnitTestBase {
         vm.roll(24);
         vm.warp(24 hours);
 
-        vm.prank(updaters[0]);
+        vm.prank(updater1);
         capAutomator.execSupply(asset);
 
         (
@@ -959,7 +965,7 @@ contract RemoveBorrowCapConfigTests is CapAutomatorUnitTestBase {
         vm.roll(36);
         vm.warp(36 hours);
 
-        vm.prank(updaters[0]);
+        vm.prank(updater1);
         capAutomator.execBorrow(asset);
 
         (
@@ -1003,14 +1009,14 @@ contract CalculateNewCapTests is Test {
     MockPoolConfigurator      public mockPoolConfigurator;
 
     address public admin;
-    address[] public updaters;
+    address public updater;
 
     CapAutomatorHarness public capAutomator;
 
     function setUp() public {
 
-        admin = makeAddr("admin");
-        updaters.push(makeAddr("updater-1"));
+        admin   = makeAddr("admin");
+        updater = makeAddr("updater");
 
         mockPool                  = new MockPool();
         mockPoolConfigurator      = new MockPoolConfigurator(mockPool);
@@ -1023,7 +1029,7 @@ contract CalculateNewCapTests is Test {
         capAutomator = new CapAutomatorHarness(
             address(mockPoolAddressesProvider),
             admin,
-            updaters[0]
+            updater
         );
         vm.stopPrank();
     }
@@ -1208,17 +1214,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
-
-        ( 
-            ,,, 
-            uint48 lastUpdateBlockBefore,
-            uint48 lastIncreaseTimeBefore
-        ) = capAutomator.supplyCapConfigs(asset);
-        assertEq(lastUpdateBlockBefore,  0);
-        assertEq(lastIncreaseTimeBefore, 0);
-
-        vm.startPrank(makeAddr("notUpdater"));
+        vm.prank(makeAddr("notUpdater"));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1227,10 +1223,9 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             )
         );
         capAutomator.execSupply(asset);
-        vm.stopPrank();
 
         // not even role admin can call execSupply
-        vm.startPrank(admin);
+        vm.prank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1239,7 +1234,6 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             )
         );
         capAutomator.execSupply(asset);
-        vm.stopPrank();
     }
 
     function test_execSupply_after_role_revoke() public {
@@ -1254,43 +1248,14 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
+        vm.prank(updater1);
+        capAutomator.execSupply(asset);
 
-        ( 
-            ,,,
-            uint48 lastUpdateBlockBefore,
-            uint48 lastIncreaseTimeBefore
-        ) = capAutomator.supplyCapConfigs(asset);
-        assertEq(lastUpdateBlockBefore,  0);
-        assertEq(lastIncreaseTimeBefore, 0);
+        // Revoke UPDATE_ROLE from updater1
 
-        vm.startPrank(updaters[0]);
-        vm.expectCall(
-            address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setSupplyCap,(asset, uint256(7_400))), 
-            1
-        );
-        assertEq(capAutomator.execSupply(asset), 7_400);
-        vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 
-        // 6900 + 500 = 7400
-
-        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
-
-        ( 
-            ,,,
-            uint48 lastUpdateBlockAfter,
-            uint48 lastIncreaseTimeAfter
-        ) = capAutomator.supplyCapConfigs(asset);
-        assertEq(lastUpdateBlockAfter,  900);
-        assertEq(lastIncreaseTimeAfter, 900_000);
-
-        // Revoke UPDATE_ROLE from updaters[0]
-
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
         vm.prank(admin);
-        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), false);
+        capAutomator.revokeRole(UPDATE_ROLE, updater1);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
 
 
         vm.roll(1000);
@@ -1304,21 +1269,11 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
-
-        ( 
-            ,,,
-            lastUpdateBlockBefore,
-            lastIncreaseTimeBefore
-        ) = capAutomator.supplyCapConfigs(asset);
-        assertEq(lastUpdateBlockBefore,  900);
-        assertEq(lastIncreaseTimeBefore, 900_000);
-
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                updaters[0],
+                updater1,
                 UPDATE_ROLE
             )
         );
@@ -1340,7 +1295,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
@@ -1348,7 +1303,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
@@ -1356,12 +1311,12 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         );
         assertEq(capAutomator.execSupply(asset), 7_400);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 
-        // 6900 + 500 = 7400
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
@@ -1384,7 +1339,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
@@ -1392,7 +1347,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
@@ -1400,12 +1355,12 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         );
         assertEq(capAutomator.execSupply(asset), 7_400);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 
-        // 6900 + 500 = 7400
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
@@ -1427,7 +1382,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
-        ( 
+        (
             ,,,
             lastUpdateBlockBefore,
             lastIncreaseTimeBefore
@@ -1435,20 +1390,20 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  900);
         assertEq(lastIncreaseTimeBefore, 900_000);
         
-        vm.startPrank(updaters[1]);
+        vm.startPrank(updater2);
         vm.expectCall(
             address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setSupplyCap,(asset, uint256(7_900))),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_900))),
             1
         );
         assertEq(capAutomator.execSupply(asset), 7_900);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 1000
-        // 6900 + 1000 = 7900
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 1000 = 6900 + 1000 = 7900
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_900);
 
-        ( 
+        (
             ,,,
             lastUpdateBlockAfter,
             lastIncreaseTimeAfter
@@ -1478,7 +1433,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
@@ -1486,7 +1441,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
         
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
@@ -1494,12 +1449,12 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         );
         assertEq(capAutomator.execSupply(asset), 7_400);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 
-        // 6900 + 500 = 7400
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
@@ -1519,7 +1474,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_000))),
@@ -1527,8 +1482,8 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         );
         assertEq(capAutomator.execSupply(asset), 7_000);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 100 
-        // 6900 + 100 = 7000
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 100 = 6900 + 100 = 7000
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
     }
@@ -1544,7 +1499,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(2_000))),
@@ -1573,16 +1528,6 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             gap:              500,
             increaseCooldown: 0
         });
-
-        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
-
-        ( 
-            ,,,
-            uint48 lastUpdateBlockBefore,
-            uint48 lastIncreaseTimeBefore
-        ) = capAutomator.borrowCapConfigs(asset);
-        assertEq(lastUpdateBlockBefore,  0);
-        assertEq(lastIncreaseTimeBefore, 0);
 
         vm.startPrank(makeAddr("notUpdater"));
         vm.expectRevert(
@@ -1620,41 +1565,13 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
+        vm.prank(updater1);
+        capAutomator.execBorrow(asset);
 
-        ( 
-            ,,,
-            uint48 lastUpdateBlockBefore,
-            uint48 lastIncreaseTimeBefore
-        ) = capAutomator.borrowCapConfigs(asset);
-        assertEq(lastUpdateBlockBefore,  0);
-        assertEq(lastIncreaseTimeBefore, 0);
-
-        vm.startPrank(updaters[0]);
-        vm.expectCall(
-            address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
-            1
-        );
-        assertEq(capAutomator.execBorrow(asset), 4_400);
-        vm.stopPrank();
-        // totalDebt + gap = 3900 + 500 = 4400
-
-        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
-
-        ( 
-            ,,,
-            uint48 lastUpdateBlockAfter,
-            uint48 lastIncreaseTimeAfter
-        ) = capAutomator.borrowCapConfigs(asset);
-        assertEq(lastUpdateBlockAfter,  100);
-        assertEq(lastIncreaseTimeAfter, 100_000);
-
-        // Revoke UPDATE_ROLE from updaters[0]
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
+        // Revoke UPDATE_ROLE from updater1
         vm.prank(admin);
-        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), false);
+        capAutomator.revokeRole(UPDATE_ROLE, updater1);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
 
         vm.roll(200);
         vm.warp(200_000);
@@ -1667,21 +1584,11 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
-
-        ( 
-            ,,,
-            lastUpdateBlockBefore,
-            lastIncreaseTimeBefore
-        ) = capAutomator.borrowCapConfigs(asset);
-        assertEq(lastUpdateBlockBefore,  100);
-        assertEq(lastIncreaseTimeBefore, 100_000);
-
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                updaters[0],
+                updater1,
                 UPDATE_ROLE
             )
         );
@@ -1703,7 +1610,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
@@ -1711,10 +1618,10 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))), 
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
             1
         );
         assertEq(capAutomator.execBorrow(asset), 4_400);
@@ -1723,7 +1630,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
@@ -1746,7 +1653,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
@@ -1754,7 +1661,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
@@ -1766,7 +1673,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
@@ -1787,7 +1694,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
-        ( 
+        (
             ,,,
             lastUpdateBlockBefore,
             lastIncreaseTimeBefore
@@ -1795,10 +1702,10 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  100);
         assertEq(lastIncreaseTimeBefore, 100_000);
 
-        vm.startPrank(updaters[1]);
+        vm.startPrank(updater2);
         vm.expectCall(
             address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_900))), 
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_900))),
             1
         );
         assertEq(capAutomator.execBorrow(asset), 4_900);
@@ -1807,7 +1714,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_900);
 
-        ( 
+        (
             ,,,
             lastUpdateBlockAfter,
             lastIncreaseTimeAfter
@@ -1833,7 +1740,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
@@ -1841,7 +1748,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
@@ -1853,7 +1760,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
-        ( 
+        (
             ,,,
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
@@ -1873,7 +1780,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))), 
@@ -1897,10 +1804,10 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
         
-        vm.startPrank(updaters[0]);
+        vm.startPrank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(1_000))), 
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(1_000))),
             1
         );
         assertEq(capAutomator.execBorrow(asset), 1_000);
@@ -1937,10 +1844,7 @@ contract ExecTests is CapAutomatorUnitTestBase {
         });
         vm.stopPrank();
 
-        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
-        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
-
-        vm.startPrank(makeAddr("notUpdater"));
+        vm.prank(makeAddr("notUpdater"));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1949,10 +1853,9 @@ contract ExecTests is CapAutomatorUnitTestBase {
             )
         );
         capAutomator.exec(asset);
-        vm.stopPrank();
 
         // not even role admin can call exec
-        vm.startPrank(admin);
+        vm.prank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1961,7 +1864,6 @@ contract ExecTests is CapAutomatorUnitTestBase {
             )
         );
         capAutomator.exec(asset);
-        vm.stopPrank();
     }
 
     function test_exec_after_role_revoke() public {
@@ -1986,36 +1888,14 @@ contract ExecTests is CapAutomatorUnitTestBase {
         });
         vm.stopPrank();
 
-        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
-        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
+        vm.prank(updater1);
+        capAutomator.exec(asset);
 
-        vm.expectCall(
-            address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))),
-            1
-        );
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 
-        // 6900 + 400 = 7300
-        vm.expectCall(
-            address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 
-            1
-        );
-        // totalDebt + gap = 3900 + 300 = 4200
-        vm.prank(updaters[0]);
-        ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
+        // Revoke UPDATE_ROLE from updater1
 
-        assertEq(newSupplyCap, 7_300);
-        assertEq(newBorrowCap, 4_200);
-
-        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_300);
-        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
-
-        // Revoke UPDATE_ROLE from updaters[0]
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
         vm.prank(admin);
-        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), false);
+        capAutomator.revokeRole(UPDATE_ROLE, updater1);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
 
         vm.roll(1000);
         vm.warp(1000_000);
@@ -2034,15 +1914,12 @@ contract ExecTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
         vm.stopPrank();
-
-        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_300);
-        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
         
-        vm.prank(updaters[0]);
+        vm.prank(updater1);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                updaters[0],
+                updater1,
                 UPDATE_ROLE
             )
         );
@@ -2076,18 +1953,18 @@ contract ExecTests is CapAutomatorUnitTestBase {
 
         vm.expectCall(
             address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))), 
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))),
             1
         );
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 
-        // 6900 + 400 = 7300
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
         vm.expectCall(
             address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))),
             1
         );
         // totalDebt + gap = 3900 + 300 = 4200
-        vm.prank(updaters[0]);
+        vm.prank(updater1);
         ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
 
         assertEq(newSupplyCap, 7_300);
@@ -2124,18 +2001,18 @@ contract ExecTests is CapAutomatorUnitTestBase {
 
         vm.expectCall(
             address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))), 
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))),
             1
         );
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 
-        // 6900 + 400 = 7300
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
         vm.expectCall(
             address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))),
             1
         );
         // totalDebt + gap = 3900 + 300 = 4200
-        vm.prank(updaters[0]);
+        vm.prank(updater1);
         ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
 
         assertEq(newSupplyCap, 7_300);
@@ -2167,18 +2044,18 @@ contract ExecTests is CapAutomatorUnitTestBase {
 
         vm.expectCall(
             address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_100))), 
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_100))),
             1
         );
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 200 
-        // 6900 + 200 = 7100
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 200 = 6900 + 200 = 7100
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))),
             1
         );
         // totalDebt + gap = 3900 + 100 = 4000
-        vm.prank(updaters[1]);
+        vm.prank(updater2);
         ( newSupplyCap, newBorrowCap ) = capAutomator.exec(asset);
 
         assertEq(newSupplyCap, 7_100);
@@ -2249,15 +2126,15 @@ contract EventTests is CapAutomatorUnitTestBase {
     function test_RoleRevoked_updateRole() public {
         vm.prank(admin);
         vm.expectEmit(address(capAutomator));
-        emit RoleRevoked(UPDATE_ROLE, updaters[0], admin);
-        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+        emit RoleRevoked(UPDATE_ROLE, updater1, admin);
+        capAutomator.revokeRole(UPDATE_ROLE, updater1);
     }
 
     function test_RoleRevoked_renounce() public {
-        vm.prank(updaters[0]);
+        vm.prank(updater1);
         vm.expectEmit(address(capAutomator));
-        emit RoleRevoked(UPDATE_ROLE, updaters[0], updaters[0]);
-        capAutomator.renounceRole(UPDATE_ROLE, updaters[0]);
+        emit RoleRevoked(UPDATE_ROLE, updater1, updater1);
+        capAutomator.renounceRole(UPDATE_ROLE, updater1);
     }
 
     function test_SetSupplyCapConfig() public {
@@ -2331,11 +2208,11 @@ contract EventTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        vm.prank(updaters[0]);
+        vm.prank(updater1);
         vm.expectEmit(address(capAutomator));
         emit UpdateSupplyCap(asset, 7_000, 7_300);
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 
-        // 6900 + 400 = 7300
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
         capAutomator.execSupply(asset);
     }
 
@@ -2348,7 +2225,7 @@ contract EventTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        vm.prank(updaters[0]);
+        vm.prank(updater1);
         vm.expectEmit(address(capAutomator));
         emit UpdateBorrowCap(asset, 4_000, 4_200);
         // totalDebt + gap = 3900 + 300 = 4200

--- a/test/CapAutomator.t.sol
+++ b/test/CapAutomator.t.sol
@@ -1139,7 +1139,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         vm.prank(unauthorized);
         capAutomator.execSupply(asset);
 
-        // Not even
+        // Not even role admin can call execSupply
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1409,7 +1409,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         vm.prank(unauthorized);
         capAutomator.execBorrow(asset);
 
-        // Not even
+        // Not even role admin can call execBorrow
         vm.prank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1667,7 +1667,7 @@ contract ExecTests is CapAutomatorUnitTestBase {
         vm.prank(unauthorized);
         capAutomator.exec(asset);
 
-        // Not even
+        // Not even role admin can call exec
         vm.prank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/test/CapAutomator.t.sol
+++ b/test/CapAutomator.t.sol
@@ -3,12 +3,13 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 
-import { Ownable } from "openzeppelin-contracts/access/Ownable.sol";
+import { IAccessControl }           from "openzeppelin-contracts/access/IAccessControl.sol";
+import { IAccessControlEnumerable } from "openzeppelin-contracts/access/extensions/IAccessControlEnumerable.sol";
 
-import { ReserveConfiguration } from "aave-v3-core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
-import { DataTypes }            from "aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
-import { IPool }                from "aave-v3-core/contracts/interfaces/IPool.sol";
-import { IPoolConfigurator }    from "aave-v3-core/contracts/interfaces/IPoolConfigurator.sol";
+import { ReserveConfiguration } from "aave-v3-core-contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
+import { DataTypes }            from "aave-v3-core-contracts/protocol/libraries/types/DataTypes.sol";
+import { IPool }                from "aave-v3-core-contracts/interfaces/IPool.sol";
+import { IPoolConfigurator }    from "aave-v3-core-contracts/interfaces/IPoolConfigurator.sol";
 
 import { MockPoolAddressesProvider } from "./mocks/MockPoolAddressesProvider.sol";
 import { MockPoolConfigurator }      from "./mocks/MockPoolConfigurator.sol";
@@ -23,13 +24,19 @@ contract CapAutomatorUnitTestBase is Test {
     MockPool                  public mockPool;
     MockPoolConfigurator      public mockPoolConfigurator;
 
-    address public owner;
+    address public admin;
+    address[] public updaters;
     address public asset;
 
     CapAutomator public capAutomator;
 
+    bytes32 public DEFAULT_ADMIN_ROLE;
+    bytes32 public UPDATE_ROLE;
+
     function setUp() public {
-        owner = makeAddr("owner");
+        admin = makeAddr("admin");
+        updaters.push(makeAddr("updater-1"));
+        updaters.push(makeAddr("updater-2"));
         asset = makeAddr("asset");
 
         mockPool                  = new MockPool();
@@ -49,9 +56,14 @@ contract CapAutomatorUnitTestBase is Test {
         mockPool.debtToken().__setDecimals(18);
         mockPool.__setTotalDebt(3_900e18);
 
-        capAutomator = new CapAutomator(address(mockPoolAddressesProvider));
+        vm.startPrank(admin);
+        capAutomator = new CapAutomator(address(mockPoolAddressesProvider), updaters[0]);
 
-        capAutomator.transferOwnership(owner);
+        DEFAULT_ADMIN_ROLE = capAutomator.DEFAULT_ADMIN_ROLE();
+        UPDATE_ROLE = capAutomator.UPDATE_ROLE();
+
+        capAutomator.grantRole(UPDATE_ROLE, updaters[1]);
+        vm.stopPrank();
     }
 
 }
@@ -59,57 +71,240 @@ contract CapAutomatorUnitTestBase is Test {
 contract ConstructorTests is CapAutomatorUnitTestBase {
 
     function test_constructor() public {
-        mockPoolAddressesProvider = new MockPoolAddressesProvider(makeAddr("pool"), makeAddr("poolConfigurator"));
-        capAutomator              = new CapAutomator(address(mockPoolAddressesProvider));
+        assertEq(address(capAutomator.pool()),             address(mockPool));
+        assertEq(address(capAutomator.poolConfigurator()), address(mockPoolConfigurator));
+        assertTrue(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin));
+        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[1]));
+    }
 
-        assertEq(address(capAutomator.pool()),             makeAddr("pool"));
-        assertEq(address(capAutomator.poolConfigurator()), makeAddr("poolConfigurator"));
-        assertEq(address(capAutomator.owner()),            address(this));
+    function test_constructor_zeroUpdater() public {
+        vm.expectRevert("CapAutomator/zero-address");
+        new CapAutomator(address(mockPoolAddressesProvider), address(0));
     }
 
 }
 
-contract TransferOwnershipTests is CapAutomatorUnitTestBase {
+contract GrantRoleTests is CapAutomatorUnitTestBase {
 
-    function test_transferOwnership_noAuth() public {
-        vm.prank(makeAddr("notOwner"));
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, makeAddr("notOwner")));
-        capAutomator.transferOwnership(makeAddr("newOwner"));
+    function test_grantRole_defaultAdminRole_noAuth() public {
+        address notAdmin = makeAddr("notAdmin");
+        address newAdmin = makeAddr("newAdmin");
+
+        vm.prank(notAdmin);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, notAdmin, DEFAULT_ADMIN_ROLE));
+        capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
     }
 
-    function test_transferOwnership_zeroAddress() public {
-        vm.prank(owner);
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableInvalidOwner.selector, address(0)));
-        capAutomator.transferOwnership(address(0));
+    function test_grantRole_defaultAdminRole() public {
+        address newAdmin = makeAddr("newAdmin");
+
+        assertFalse(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin));
+
+        vm.prank(admin);
+        capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
+
+        assertTrue(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin));
     }
 
-    function test_transferOwnership() public {
-        address newOwner = makeAddr("newOwner");
-        assertEq(capAutomator.owner(), owner);
+    function test_grantRole_updateRole_noAuth() public {
+        address notAdmin = makeAddr("notAdmin");
+        address newUpdater = makeAddr("newUpdater");
 
-        vm.prank(owner);
-        capAutomator.transferOwnership(newOwner);
+        vm.prank(notAdmin);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, notAdmin, DEFAULT_ADMIN_ROLE));
+        capAutomator.grantRole(UPDATE_ROLE, newUpdater);
+    }
 
-        assertEq(capAutomator.owner(), newOwner);
+    function test_grantRole_updateRole() public {
+        address newUpdater = makeAddr("newUpdater");
+
+        assertFalse(capAutomator.hasRole(UPDATE_ROLE, newUpdater));
+
+        vm.prank(admin);
+        capAutomator.grantRole(UPDATE_ROLE, newUpdater);
+
+        assertTrue(capAutomator.hasRole(UPDATE_ROLE, newUpdater));
     }
 
 }
 
-contract RenounceOwnershipTests is CapAutomatorUnitTestBase {
+contract RenounceRoleTests is CapAutomatorUnitTestBase {
 
-    function test_renounceOwnership_noAuth() public {
-        vm.prank(makeAddr("notOwner"));
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, makeAddr("notOwner")));
-        capAutomator.renounceOwnership();
+    function test_renounceAdminRole_badConfirmation() public {
+        vm.prank(makeAddr("notAdmin"));
+        vm.expectRevert(IAccessControl.AccessControlBadConfirmation.selector);
+        capAutomator.renounceRole(DEFAULT_ADMIN_ROLE, admin);
     }
 
-    function test_renounceOwnership() public {
-        assertEq(capAutomator.owner(), owner);
+    function test_renounceAdminRole() public {
+        assertTrue(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin));
 
-        vm.prank(owner);
-        capAutomator.renounceOwnership();
+        vm.prank(admin);
+        capAutomator.renounceRole(DEFAULT_ADMIN_ROLE, admin);
 
-        assertEq(capAutomator.owner(), address(0));
+        assertFalse(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin));
+    }
+
+    function test_renounceUpdateRole_badConfirmation() public {
+        vm.prank(makeAddr("notUpdater"));
+        vm.expectRevert(IAccessControl.AccessControlBadConfirmation.selector);
+        capAutomator.renounceRole(UPDATE_ROLE, updaters[0]);
+    }
+
+    function test_renounceUpdateRole() public {
+        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+
+        vm.prank(updaters[0]);
+        capAutomator.renounceRole(UPDATE_ROLE, updaters[0]);
+
+        assertFalse(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+    }
+
+}
+
+contract RevokeRoleTests is CapAutomatorUnitTestBase {
+
+    function test_revokeAdminRole_noAuth() public {
+        address notAdmin = makeAddr("notAdmin");
+
+        vm.prank(notAdmin);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, notAdmin, DEFAULT_ADMIN_ROLE));
+        capAutomator.revokeRole(DEFAULT_ADMIN_ROLE, admin);
+    }
+
+    function test_revokeAdminRole() public {
+        address newAdmin = makeAddr("newAdmin");
+
+        vm.prank(admin);
+        capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
+        assertTrue(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin));
+
+        vm.prank(admin);
+        capAutomator.revokeRole(DEFAULT_ADMIN_ROLE, newAdmin);
+
+        assertFalse(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin));
+
+        vm.prank(admin);
+        capAutomator.revokeRole(DEFAULT_ADMIN_ROLE, admin);
+
+        assertFalse(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin));
+    }
+
+    function test_revokeUpdateRole_noAuth() public {
+        address notAdmin = makeAddr("notAdmin");
+
+        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+
+        vm.prank(notAdmin);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, notAdmin, DEFAULT_ADMIN_ROLE));
+        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+
+        // self revoking role
+        vm.prank(updaters[0]);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, updaters[0], DEFAULT_ADMIN_ROLE));
+        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+    }
+
+    function test_revokeUpdateRole() public {
+        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+
+        vm.prank(admin);
+        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+
+        assertFalse(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+    }
+
+}
+
+contract GetRoleAdminTests is CapAutomatorUnitTestBase {
+
+    function test_getRoleAdmin_defaultAdminRole() public {
+        assertEq(capAutomator.getRoleAdmin(DEFAULT_ADMIN_ROLE), DEFAULT_ADMIN_ROLE);
+    }
+
+    function test_getRoleAdmin_updateRole() public {
+        assertEq(capAutomator.getRoleAdmin(UPDATE_ROLE), DEFAULT_ADMIN_ROLE);
+    }
+}
+
+contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
+
+    function test_getRoleMemberCount_defaultAdminRole() public {
+        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
+    }
+
+    function test_getRoleMemberCount_updateRole() public {
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 2);
+    }
+
+    function test_getRoleMember_defaultAdminRole() public {
+        assertEq(capAutomator.getRoleMember(DEFAULT_ADMIN_ROLE, 0), admin);
+    }
+
+    function test_getRoleMember_updateRole() public {
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0), updaters[0]);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 1), updaters[1]);
+    }
+
+    function test_getRoleMemberCount_afterGrant() public {
+        address newAdmin = makeAddr("newAdmin");
+
+        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
+
+        vm.prank(admin);
+        capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
+
+        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 2);
+        assertEq(capAutomator.getRoleMember(DEFAULT_ADMIN_ROLE, 1), newAdmin);
+
+        address newUpdater = makeAddr("newUpdater");
+
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 2);
+
+        vm.prank(admin);
+        capAutomator.grantRole(UPDATE_ROLE, newUpdater);
+
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 3);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 2), newUpdater);
+    }
+
+    function test_getRoleMemberCount_afterRevoke() public {
+        // Test revoking UPDATE_ROLE first (while admin still has permissions)
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 2);
+
+        vm.prank(admin);
+        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 1);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0), updaters[1]);
+
+        // Test revoking DEFAULT_ADMIN_ROLE
+        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
+
+        vm.prank(admin);
+        capAutomator.revokeRole(DEFAULT_ADMIN_ROLE, admin);
+
+        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 0);
+    }
+
+    function test_getRoleMemberCount_afterRenounce() public {
+        // Test renouncing UPDATE_ROLE
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 2);
+
+        vm.prank(updaters[0]);
+        capAutomator.renounceRole(UPDATE_ROLE, updaters[0]);
+
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 1);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0), updaters[1]);
+
+        // Test renouncing DEFAULT_ADMIN_ROLE
+        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
+
+        vm.prank(admin);
+        capAutomator.renounceRole(DEFAULT_ADMIN_ROLE, admin);
+
+        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 0);
     }
 
 }
@@ -117,8 +312,8 @@ contract RenounceOwnershipTests is CapAutomatorUnitTestBase {
 contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setSupplyCapConfig_noAuth() public {
-        vm.prank(makeAddr("notOwner"));
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, makeAddr("notOwner")));
+        vm.prank(makeAddr("notAdmin"));
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notAdmin"), DEFAULT_ADMIN_ROLE));
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -126,7 +321,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -137,7 +332,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setSupplyCapConfig_zeroCap() public {
         vm.expectRevert("CapAutomator/zero-cap");
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             0,
@@ -145,7 +340,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             2,
@@ -156,7 +351,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setSupplyCapConfig_zeroGap() public {
         vm.expectRevert("CapAutomator/zero-gap");
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             2,
@@ -164,7 +359,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             2,
@@ -177,7 +372,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(ReserveConfiguration.MAX_VALID_SUPPLY_CAP, 68_719_476_735);
 
         vm.expectRevert("CapAutomator/invalid-cap");
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             ReserveConfiguration.MAX_VALID_SUPPLY_CAP + 1,
@@ -185,7 +380,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             ReserveConfiguration.MAX_VALID_SUPPLY_CAP,
@@ -196,7 +391,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setSupplyCapConfig_invalidGap() public {
         vm.expectRevert("CapAutomator/invalid-gap");
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -204,7 +399,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -215,7 +410,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setSupplyCapConfig_invalidCooldown() public {
         vm.expectRevert("CapAutomator/uint48-cast");
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -223,7 +418,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             uint256(type(uint48).max) + 1
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -247,7 +442,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlock,  0);
         assertEq(lastIncreaseTime, 0);
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -271,7 +466,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
     }
 
     function test_setSupplyCapConfig_reconfigure() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -290,7 +485,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(gap,              1_000);
         assertEq(increaseCooldown, 12 hours);
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             13_000,
@@ -311,7 +506,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
     }
 
     function test_setSupplyCapConfig_preserveUpdateTrackers() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -326,6 +521,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
         vm.roll(120_000);
         vm.warp(12 hours);
+        vm.prank(updaters[0]);
         capAutomator.exec(asset);
 
         ( ,,, uint48 postExecUpdateBlock, uint48 postExecIncreaseTime ) = capAutomator.supplyCapConfigs(asset);
@@ -333,7 +529,7 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(postExecUpdateBlock,  120_000);
         assertEq(postExecIncreaseTime, 12 hours);
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             20_000,
@@ -352,8 +548,8 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setBorrowCapConfig_noAuth() public {
-        vm.prank(makeAddr("notOwner"));
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, makeAddr("notOwner")));
+        vm.prank(makeAddr("notAdmin"));
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notAdmin"), DEFAULT_ADMIN_ROLE));
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -361,7 +557,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -372,7 +568,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setBorrowCapConfig_zeroCap() public {
         vm.expectRevert("CapAutomator/zero-cap");
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             0,
@@ -380,7 +576,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             2,
@@ -391,7 +587,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setBorrowCapConfig_zeroGap() public {
         vm.expectRevert("CapAutomator/zero-gap");
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             2,
@@ -399,7 +595,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             2,
@@ -412,7 +608,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(ReserveConfiguration.MAX_VALID_BORROW_CAP, 68_719_476_735);
 
         vm.expectRevert("CapAutomator/invalid-cap");
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             ReserveConfiguration.MAX_VALID_BORROW_CAP + 1,
@@ -420,7 +616,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             ReserveConfiguration.MAX_VALID_BORROW_CAP,
@@ -431,7 +627,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setBorrowCapConfig_invalidGap() public {
         vm.expectRevert("CapAutomator/invalid-gap");
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -439,7 +635,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -450,7 +646,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setBorrowCapConfig_invalidCooldown() public {
         vm.expectRevert("CapAutomator/uint48-cast");
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -458,7 +654,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             uint256(type(uint48).max) + 1
         );
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -482,7 +678,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlock,  0);
         assertEq(lastIncreaseTime, 0);
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -506,7 +702,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
     }
 
     function test_setBorrowCapConfig_reconfigure() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -525,7 +721,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(gap,              1_000);
         assertEq(increaseCooldown, 12 hours);
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             13_000,
@@ -546,7 +742,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
     }
 
     function test_setBorrowCapConfig_preserveUpdateTrackers() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -561,6 +757,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
         vm.roll(600);
         vm.warp(12 hours);
+        vm.prank(updaters[0]);
         capAutomator.exec(asset);
 
         ( ,,, uint48 postExecUpdateBlock, uint48 postExecIncreaseTime ) = capAutomator.borrowCapConfigs(asset);
@@ -568,7 +765,7 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(postExecUpdateBlock,  600);
         assertEq(postExecIncreaseTime, 12 hours);
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             20_000,
@@ -587,19 +784,20 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 contract RemoveSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_removeSupplyCapConfig_noAuth() public {
-        vm.prank(makeAddr("notOwner"));
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, makeAddr("notOwner")));
+        vm.prank(makeAddr("notAdmin"));
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notAdmin"), DEFAULT_ADMIN_ROLE));
+
         capAutomator.removeSupplyCapConfig(asset);
     }
 
     function test_removeSupplyCapConfig_nonexistentConfig() public {
-        vm.prank(owner);
+        vm.prank(admin);
         vm.expectRevert("CapAutomator/nonexistent-config");
         capAutomator.removeSupplyCapConfig(asset);
     }
 
     function test_removeSupplyCapConfig() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -610,6 +808,7 @@ contract RemoveSupplyCapConfigTests is CapAutomatorUnitTestBase {
         vm.roll(24);
         vm.warp(24 hours);
 
+        vm.prank(updaters[0]);
         capAutomator.execSupply(asset);
 
         (
@@ -626,7 +825,7 @@ contract RemoveSupplyCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlock,  24);
         assertEq(lastIncreaseTime, 24 hours);
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.removeSupplyCapConfig(asset);
 
         (
@@ -649,19 +848,19 @@ contract RemoveSupplyCapConfigTests is CapAutomatorUnitTestBase {
 contract RemoveBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_removeBorrowCapConfig_noAuth() public {
-        vm.prank(makeAddr("notOwner"));
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, makeAddr("notOwner")));
+        vm.prank(makeAddr("notAdmin"));
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notAdmin"), DEFAULT_ADMIN_ROLE));
         capAutomator.removeBorrowCapConfig(asset);
     }
 
     function test_removeBorrowCapConfig_nonexistentConfig() public {
-        vm.prank(owner);
+        vm.prank(admin);
         vm.expectRevert("CapAutomator/nonexistent-config");
         capAutomator.removeBorrowCapConfig(asset);
     }
 
     function test_removeBorrowCapConfig() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -672,6 +871,7 @@ contract RemoveBorrowCapConfigTests is CapAutomatorUnitTestBase {
         vm.roll(36);
         vm.warp(36 hours);
 
+        vm.prank(updaters[0]);
         capAutomator.execBorrow(asset);
 
         (
@@ -688,7 +888,7 @@ contract RemoveBorrowCapConfigTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlock,  36);
         assertEq(lastIncreaseTime, 36 hours);
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.removeBorrowCapConfig(asset);
 
         (
@@ -714,18 +914,23 @@ contract CalculateNewCapTests is Test {
     MockPool                  public mockPool;
     MockPoolConfigurator      public mockPoolConfigurator;
 
-    address public owner;
+    address public admin;
+    address[] public updaters;
 
     CapAutomatorHarness public capAutomator;
 
     function setUp() public {
-        owner = makeAddr("owner");
+
+        admin = makeAddr("admin");
+        updaters.push(makeAddr("updater-1"));
 
         mockPool                  = new MockPool();
         mockPoolConfigurator      = new MockPoolConfigurator(mockPool);
         mockPoolAddressesProvider = new MockPoolAddressesProvider(address(mockPool), address(mockPoolConfigurator));
 
-        capAutomator = new CapAutomatorHarness(address(mockPoolAddressesProvider));
+        vm.startPrank(admin);
+        capAutomator = new CapAutomatorHarness(address(mockPoolAddressesProvider), updaters[0]);
+        vm.stopPrank();
     }
 
     function test_calculateNewCap_raiseCap() public {
@@ -896,11 +1101,11 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
-    function test_execSupply() public {
+    function test_execSupply_noAuth() public {
         vm.roll(900);
         vm.warp(900_000);
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
             max:              10_000,
@@ -914,8 +1119,100 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
+        vm.startPrank(makeAddr("notUpdater"));
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notUpdater"), UPDATE_ROLE));
+        capAutomator.execSupply(asset);
+        vm.stopPrank();
+
+        // not even role admin can call execSupply
+        vm.startPrank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, UPDATE_ROLE));
+        capAutomator.execSupply(asset);
+        vm.stopPrank();
+    }
+
+    function test_execSupply_after_role_revoke() public {
+        vm.roll(900);
+        vm.warp(900_000);
+
+        vm.prank(admin);
+        capAutomator.setSupplyCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              500,
+            increaseCooldown: 0
+        });
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
+
+        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        assertEq(lastUpdateBlockBefore,  0);
+        assertEq(lastIncreaseTimeBefore, 0);
+
+        vm.startPrank(updaters[0]);
         vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))), 1);
         assertEq(capAutomator.execSupply(asset), 7_400);
+        vm.stopPrank();
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
+
+        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.supplyCapConfigs(asset);
+        assertEq(lastUpdateBlockAfter,  900);
+        assertEq(lastIncreaseTimeAfter, 900_000);
+
+        // Revoke UPDATE_ROLE from updaters[0]
+        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        vm.prank(admin);
+        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+        assertFalse(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+
+
+        vm.roll(1000);
+        vm.warp(1000_000);
+
+        vm.prank(admin);
+        capAutomator.setSupplyCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              1000,
+            increaseCooldown: 0
+        });
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
+
+        ( ,,, lastUpdateBlockBefore, lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        assertEq(lastUpdateBlockBefore,  900);
+        assertEq(lastIncreaseTimeBefore, 900_000);
+
+        vm.startPrank(updaters[0]);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, updaters[0], UPDATE_ROLE));
+        capAutomator.execSupply(asset);
+        vm.stopPrank();
+    }
+
+    function test_execSupply() public {
+        vm.roll(900);
+        vm.warp(900_000);
+
+        vm.prank(admin);
+        capAutomator.setSupplyCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              500,
+            increaseCooldown: 0
+        });
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
+
+        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        assertEq(lastUpdateBlockBefore,  0);
+        assertEq(lastIncreaseTimeBefore, 0);
+
+        vm.startPrank(updaters[0]);
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))), 1);
+        assertEq(capAutomator.execSupply(asset), 7_400);
+        vm.stopPrank();
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
@@ -924,6 +1221,67 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockAfter,  900);
         assertEq(lastIncreaseTimeAfter, 900_000);
     }
+
+    function test_execSupply_multiple_updaters() public {
+        vm.roll(900);
+        vm.warp(900_000);
+
+        vm.prank(admin);
+        capAutomator.setSupplyCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              500,
+            increaseCooldown: 0
+        });
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
+
+        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        assertEq(lastUpdateBlockBefore,  0);
+        assertEq(lastIncreaseTimeBefore, 0);
+
+        vm.startPrank(updaters[0]);
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))), 1);
+        assertEq(capAutomator.execSupply(asset), 7_400);
+        vm.stopPrank();
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
+
+        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.supplyCapConfigs(asset);
+        assertEq(lastUpdateBlockAfter,  900);
+        assertEq(lastIncreaseTimeAfter, 900_000);
+
+        vm.roll(1800);
+        vm.warp(1800_000);
+
+        vm.prank(admin);
+        capAutomator.setSupplyCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              1000,
+            increaseCooldown: 0
+        });
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
+
+        ( ,,, lastUpdateBlockBefore, lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        assertEq(lastUpdateBlockBefore,  900);
+        assertEq(lastIncreaseTimeBefore, 900_000);
+        
+        vm.startPrank(updaters[1]);
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_900))), 1);
+        assertEq(capAutomator.execSupply(asset), 7_900);
+        vm.stopPrank();
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 1000 = 6900 + 1000 = 7900
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_900);
+
+        ( ,,, lastUpdateBlockAfter, lastIncreaseTimeAfter ) = capAutomator.supplyCapConfigs(asset);
+        assertEq(lastUpdateBlockAfter,  1800);
+        assertEq(lastIncreaseTimeAfter, 1800_000);
+    }
+
 
     function test_execSupply_differentDecimals() public {
         vm.roll(300);
@@ -935,7 +1293,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         mockPool.__setLiquidityIndex(1.5e27);
         // (aToken. scaledTotalSupply + accruedToTreasury) * liquidityIndex = 6_900e6
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
             max:              10_000,
@@ -948,9 +1306,11 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
-
+        
+        vm.startPrank(updaters[0]);
         vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))), 1);
         assertEq(capAutomator.execSupply(asset), 7_400);
+        vm.stopPrank();
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
@@ -961,7 +1321,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
     }
 
     function test_execSupply_sameCap() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
             max:              10_000,
@@ -971,15 +1331,17 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
+        vm.startPrank(updaters[0]);
         vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_000))), 0);
         assertEq(capAutomator.execSupply(asset), 7_000);
+        vm.stopPrank();
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 100 = 6900 + 100 = 7000
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
     }
 
     function test_execSupply_belowState() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
             max:              2_000,
@@ -989,8 +1351,10 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
+        vm.startPrank(updaters[0]);
         vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(2_000))), 1);
         assertEq(capAutomator.execSupply(asset), 2_000);
+        vm.stopPrank();
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 2_000);
     }
@@ -1001,11 +1365,11 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
-    function test_execBorrow() public {
+    function test_execBorrow_noAuth() public {
         vm.roll(100);
         vm.warp(100_000);
 
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
             max:              10_000,
@@ -1019,8 +1383,99 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
+        vm.startPrank(makeAddr("notUpdater"));
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notUpdater"), UPDATE_ROLE));
+        capAutomator.execBorrow(asset);
+        vm.stopPrank();
+
+        // not even role admin can call execBorrow
+        vm.startPrank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, UPDATE_ROLE));
+        capAutomator.execBorrow(asset);
+        vm.stopPrank();
+    }
+
+    function test_execBorrow_after_role_revoke() public {
+        vm.roll(100);
+        vm.warp(100_000);
+
+        vm.prank(admin);
+        capAutomator.setBorrowCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              500,
+            increaseCooldown: 0
+        });
+
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
+
+        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        assertEq(lastUpdateBlockBefore,  0);
+        assertEq(lastIncreaseTimeBefore, 0);
+
+        vm.startPrank(updaters[0]);
         vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))), 1);
         assertEq(capAutomator.execBorrow(asset), 4_400);
+        vm.stopPrank();
+        // totalDebt + gap = 3900 + 500 = 4400
+
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
+
+        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.borrowCapConfigs(asset);
+        assertEq(lastUpdateBlockAfter,  100);
+        assertEq(lastIncreaseTimeAfter, 100_000);
+
+        // Revoke UPDATE_ROLE from updaters[0]
+        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        vm.prank(admin);
+        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+        assertFalse(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+
+        vm.roll(200);
+        vm.warp(200_000);
+
+        vm.prank(admin);
+        capAutomator.setBorrowCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              100,
+            increaseCooldown: 0
+        });
+
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
+
+        ( ,,, lastUpdateBlockBefore, lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        assertEq(lastUpdateBlockBefore,  100);
+        assertEq(lastIncreaseTimeBefore, 100_000);
+
+        vm.startPrank(updaters[0]);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, updaters[0], UPDATE_ROLE));
+        capAutomator.execBorrow(asset);
+        vm.stopPrank();
+    }
+
+    function test_execBorrow() public {
+        vm.roll(100);
+        vm.warp(100_000);
+
+        vm.prank(admin);
+        capAutomator.setBorrowCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              500,
+            increaseCooldown: 0
+        });
+
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
+
+        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        assertEq(lastUpdateBlockBefore,  0);
+        assertEq(lastIncreaseTimeBefore, 0);
+
+        vm.startPrank(updaters[0]);
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))), 1);
+        assertEq(capAutomator.execBorrow(asset), 4_400);
+        vm.stopPrank();
         // totalDebt + gap = 3900 + 500 = 4400
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
@@ -1030,14 +1485,11 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastIncreaseTimeAfter, 100_000);
     }
 
-    function test_execBorrow_differentDecimals() public {
-        vm.roll(200);
-        vm.warp(200_000);
+    function test_execBorrow_multiple_updaters() public {
+        vm.roll(100);
+        vm.warp(100_000);
 
-        mockPool.debtToken().__setDecimals(6);
-        mockPool.__setTotalDebt(3_900e6);
-
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
             max:              10_000,
@@ -1051,8 +1503,73 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
+        vm.startPrank(updaters[0]);
         vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))), 1);
         assertEq(capAutomator.execBorrow(asset), 4_400);
+        vm.stopPrank();
+        // totalDebt + gap = 3900 + 500 = 4400
+
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
+
+        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.borrowCapConfigs(asset);
+        assertEq(lastUpdateBlockAfter,  100);
+        assertEq(lastIncreaseTimeAfter, 100_000);
+
+        vm.roll(200);
+        vm.warp(200_000);
+
+        vm.prank(admin);
+        capAutomator.setBorrowCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              1000,
+            increaseCooldown: 0
+        });
+
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
+
+        ( ,,, lastUpdateBlockBefore, lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        assertEq(lastUpdateBlockBefore,  100);
+        assertEq(lastIncreaseTimeBefore, 100_000);
+
+        vm.startPrank(updaters[1]);
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_900))), 1);
+        assertEq(capAutomator.execBorrow(asset), 4_900);
+        vm.stopPrank();
+        // totalDebt + gap = 3900 + 1000 = 4900
+
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_900);
+
+        ( ,,, lastUpdateBlockAfter, lastIncreaseTimeAfter ) = capAutomator.borrowCapConfigs(asset);
+        assertEq(lastUpdateBlockAfter,  200);
+        assertEq(lastIncreaseTimeAfter, 200_000);
+    }
+
+    function test_execBorrow_differentDecimals() public {
+        vm.roll(200);
+        vm.warp(200_000);
+
+        mockPool.debtToken().__setDecimals(6);
+        mockPool.__setTotalDebt(3_900e6);
+
+        vm.prank(admin);
+        capAutomator.setBorrowCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              500,
+            increaseCooldown: 0
+        });
+
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
+
+        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        assertEq(lastUpdateBlockBefore,  0);
+        assertEq(lastIncreaseTimeBefore, 0);
+
+        vm.startPrank(updaters[0]);
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))), 1);
+        assertEq(capAutomator.execBorrow(asset), 4_400);
+        vm.stopPrank();
         // totalDebt + gap = 3900 + 500 = 4400
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
@@ -1063,7 +1580,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
     }
 
     function test_execBorrow_sameCap() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
             max:              10_000,
@@ -1073,15 +1590,17 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
+        vm.startPrank(updaters[0]);
         vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))), 0);
         assertEq(capAutomator.execBorrow(asset), 4_000);
+        vm.stopPrank();
         // totalDebt + gap = 3900 + 100 = 4000
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
     }
 
     function test_execBorrow_belowState() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
             max:              1_000,
@@ -1090,9 +1609,11 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         });
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
-
+        
+        vm.startPrank(updaters[0]);
         vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(1_000))), 1);
         assertEq(capAutomator.execBorrow(asset), 1_000);
+        vm.stopPrank();
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 1_000);
     }
@@ -1103,14 +1624,51 @@ contract ExecTests is CapAutomatorUnitTestBase {
 
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
-    function test_exec() public {
+    function test_exec_noAuth() public {
         mockPool.__setSupplyCap(7_000);
         mockPool.__setBorrowCap(4_000);
 
         vm.roll(500);
         vm.warp(500_000);
 
-        vm.startPrank(owner);
+        vm.startPrank(admin);
+        capAutomator.setSupplyCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              400,
+            increaseCooldown: 0
+        });
+        capAutomator.setBorrowCapConfig({
+            asset:            asset,
+            max:              8_000,
+            gap:              300,
+            increaseCooldown: 0
+        });
+        vm.stopPrank();
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
+
+        vm.startPrank(makeAddr("notUpdater"));
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notUpdater"), UPDATE_ROLE));
+        capAutomator.exec(asset);
+        vm.stopPrank();
+
+        // not even role admin can call exec
+        vm.startPrank(admin);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, UPDATE_ROLE));
+        capAutomator.exec(asset);
+        vm.stopPrank();
+    }
+
+    function test_exec_after_role_revoke() public {
+        mockPool.__setSupplyCap(7_000);
+        mockPool.__setBorrowCap(4_000);
+
+        vm.roll(500);
+        vm.warp(500_000);
+
+        vm.startPrank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
             max:              10_000,
@@ -1132,7 +1690,77 @@ contract ExecTests is CapAutomatorUnitTestBase {
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
         vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 1);
         // totalDebt + gap = 3900 + 300 = 4200
+        vm.prank(updaters[0]);
+        ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
 
+        assertEq(newSupplyCap, 7_300);
+        assertEq(newBorrowCap, 4_200);
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_300);
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
+
+        // Revoke UPDATE_ROLE from updaters[0]
+        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        vm.prank(admin);
+        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+        assertFalse(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+
+        vm.roll(1000);
+        vm.warp(1000_000);
+
+        vm.startPrank(admin);
+        capAutomator.setSupplyCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              200,
+            increaseCooldown: 0
+        });
+        capAutomator.setBorrowCapConfig({
+            asset:            asset,
+            max:              8_000,
+            gap:              100,
+            increaseCooldown: 0
+        });
+        vm.stopPrank();
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_300);
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
+        
+        vm.prank(updaters[0]);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, updaters[0], UPDATE_ROLE));
+        capAutomator.exec(asset);
+    }
+
+    function test_exec() public {
+        mockPool.__setSupplyCap(7_000);
+        mockPool.__setBorrowCap(4_000);
+
+        vm.roll(500);
+        vm.warp(500_000);
+
+        vm.startPrank(admin);
+        capAutomator.setSupplyCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              400,
+            increaseCooldown: 0
+        });
+        capAutomator.setBorrowCapConfig({
+            asset:            asset,
+            max:              8_000,
+            gap:              300,
+            increaseCooldown: 0
+        });
+        vm.stopPrank();
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
+
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))), 1);
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 1);
+        // totalDebt + gap = 3900 + 300 = 4200
+        vm.prank(updaters[0]);
         ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
 
         assertEq(newSupplyCap, 7_300);
@@ -1142,11 +1770,88 @@ contract ExecTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
     }
 
+    function test_exec_multiple_updaters() public {
+        mockPool.__setSupplyCap(7_000);
+        mockPool.__setBorrowCap(4_000);
+
+        vm.roll(500);
+        vm.warp(500_000);
+
+        vm.startPrank(admin);
+        capAutomator.setSupplyCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              400,
+            increaseCooldown: 0
+        });
+        capAutomator.setBorrowCapConfig({
+            asset:            asset,
+            max:              8_000,
+            gap:              300,
+            increaseCooldown: 0
+        });
+        vm.stopPrank();
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
+
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))), 1);
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 1);
+        // totalDebt + gap = 3900 + 300 = 4200
+        vm.prank(updaters[0]);
+        ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
+
+        assertEq(newSupplyCap, 7_300);
+        assertEq(newBorrowCap, 4_200);
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_300);
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
+
+        vm.roll(1000);
+        vm.warp(1000_000);
+
+        vm.startPrank(admin);
+        capAutomator.setSupplyCapConfig({
+            asset:            asset,
+            max:              10_000,
+            gap:              200,
+            increaseCooldown: 0
+        });
+        capAutomator.setBorrowCapConfig({
+            asset:            asset,
+            max:              8_000,
+            gap:              100,
+            increaseCooldown: 0
+        });
+        vm.stopPrank();
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_300);
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
+
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_100))), 1);
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 200 = 6900 + 200 = 7100
+        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))), 1);
+        // totalDebt + gap = 3900 + 100 = 4000
+        vm.prank(updaters[1]);
+        ( newSupplyCap, newBorrowCap ) = capAutomator.exec(asset);
+
+        assertEq(newSupplyCap, 7_100);
+        assertEq(newBorrowCap, 4_000);
+
+        assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_100);
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
+    }
+
 }
 
 contract EventTests is CapAutomatorUnitTestBase {
-    event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
 
+    // AccessControl events
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
+    // CapAutomator events
     event SetSupplyCapConfig(address indexed asset, uint256 max, uint256 gap, uint256 increaseCooldown);
     event SetBorrowCapConfig(address indexed asset, uint256 max, uint256 gap, uint256 increaseCooldown);
 
@@ -1156,16 +1861,52 @@ contract EventTests is CapAutomatorUnitTestBase {
     event UpdateSupplyCap(address indexed asset, uint256 oldSupplyCap, uint256 newSupplyCap);
     event UpdateBorrowCap(address indexed asset, uint256 oldBorrowCap, uint256 newBorrowCap);
 
-    function test_OwnershipTransferred() public {
-        address newOwner = makeAddr("newOwner");
-        vm.prank(owner);
+    function test_RoleGranted_defaultAdminRole() public {
+        address newAdmin = makeAddr("newAdmin");
+
+        vm.prank(admin);
         vm.expectEmit(address(capAutomator));
-        emit OwnershipTransferred(owner, newOwner);
-        capAutomator.transferOwnership(newOwner);
+        emit RoleGranted(DEFAULT_ADMIN_ROLE, newAdmin, admin);
+        capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
+    }
+
+    function test_RoleGranted_updateRole() public {
+        address newUpdater = makeAddr("newUpdater");
+
+        vm.prank(admin);
+        vm.expectEmit(address(capAutomator));
+        emit RoleGranted(UPDATE_ROLE, newUpdater, admin);
+        capAutomator.grantRole(UPDATE_ROLE, newUpdater);
+    }
+
+    function test_RoleRevoked_defaultAdminRole() public {
+        address newAdmin = makeAddr("newAdmin");
+
+        vm.startPrank(admin);
+        capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
+
+        vm.expectEmit(address(capAutomator));
+        emit RoleRevoked(DEFAULT_ADMIN_ROLE, newAdmin, admin);
+        capAutomator.revokeRole(DEFAULT_ADMIN_ROLE, newAdmin);
+        vm.stopPrank();
+    }
+
+    function test_RoleRevoked_updateRole() public {
+        vm.prank(admin);
+        vm.expectEmit(address(capAutomator));
+        emit RoleRevoked(UPDATE_ROLE, updaters[0], admin);
+        capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
+    }
+
+    function test_RoleRevoked_renounce() public {
+        vm.prank(updaters[0]);
+        vm.expectEmit(address(capAutomator));
+        emit RoleRevoked(UPDATE_ROLE, updaters[0], updaters[0]);
+        capAutomator.renounceRole(UPDATE_ROLE, updaters[0]);
     }
 
     function test_SetSupplyCapConfig() public {
-        vm.prank(owner);
+        vm.prank(admin);
         vm.expectEmit(address(capAutomator));
         emit SetSupplyCapConfig(
             asset,
@@ -1182,7 +1923,7 @@ contract EventTests is CapAutomatorUnitTestBase {
     }
 
     function test_SetBorrowCapConfig() public {
-        vm.prank(owner);
+        vm.prank(admin);
         vm.expectEmit(address(capAutomator));
         emit SetBorrowCapConfig(
             asset,
@@ -1199,7 +1940,7 @@ contract EventTests is CapAutomatorUnitTestBase {
     }
 
     function test_RemoveSupplyCapConfig() public {
-        vm.startPrank(owner);
+        vm.startPrank(admin);
         capAutomator.setSupplyCapConfig(
             asset,
             20_000,
@@ -1213,7 +1954,7 @@ contract EventTests is CapAutomatorUnitTestBase {
     }
 
     function test_RemoveBorrowCapConfig() public {
-        vm.startPrank(owner);
+        vm.startPrank(admin);
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -1227,7 +1968,7 @@ contract EventTests is CapAutomatorUnitTestBase {
     }
 
     function test_UpdateSupplyCap() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
             max:              10_000,
@@ -1235,14 +1976,15 @@ contract EventTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
+        vm.prank(updaters[0]);
         vm.expectEmit(address(capAutomator));
         emit UpdateSupplyCap(asset, 7_000, 7_300);
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
-        capAutomator.exec(asset);
+        capAutomator.execSupply(asset);
     }
 
     function test_UpdateBorrowCap() public {
-        vm.prank(owner);
+        vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
             max:              8_000,
@@ -1250,6 +1992,7 @@ contract EventTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
+        vm.prank(updaters[0]);
         vm.expectEmit(address(capAutomator));
         emit UpdateBorrowCap(asset, 4_000, 4_200);
         // totalDebt + gap = 3900 + 300 = 4200

--- a/test/CapAutomator.t.sol
+++ b/test/CapAutomator.t.sol
@@ -78,13 +78,13 @@ contract CapAutomatorUnitTestBase is Test {
 
 contract ConstructorTests is CapAutomatorUnitTestBase {
 
-    function test_constructor() public {
+    function test_constructor_setsInitialState() public {
         assertEq(address(capAutomator.pool()),             address(mockPool));
         assertEq(address(capAutomator.poolConfigurator()), address(mockPoolConfigurator));
 
-        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin), true);
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1),     true);
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater2),     true);
+        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin),    true);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE,        updater1), true);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE,        updater2), true);
     }
 
     function test_constructor_zeroAddress() public {
@@ -93,9 +93,6 @@ contract ConstructorTests is CapAutomatorUnitTestBase {
 
         vm.expectRevert("CapAutomator/invalid-updater-address");
         new CapAutomator(address(mockPoolAddressesProvider), admin, address(0));
-
-        vm.expectRevert("CapAutomator/invalid-admin-address");
-        new CapAutomator(address(mockPoolAddressesProvider), address(0), address(0));
     }
 
 }
@@ -103,21 +100,17 @@ contract ConstructorTests is CapAutomatorUnitTestBase {
 contract GrantRoleTests is CapAutomatorUnitTestBase {
 
     function test_grantRole_defaultAdminRole_noAuth() public {
-        address notAdmin = makeAddr("notAdmin");
-        address newAdmin = makeAddr("newAdmin");
-
-        vm.prank(notAdmin);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                notAdmin,
+                address(this),
                 DEFAULT_ADMIN_ROLE
             )
         );
-        capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
+        capAutomator.grantRole(DEFAULT_ADMIN_ROLE, makeAddr("newAdmin"));
     }
 
-    function test_grantRole_defaultAdminRole() public {
+    function test_grantRole_grantsDefaultAdmin() public {
         address newAdmin = makeAddr("newAdmin");
 
         assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), false);
@@ -129,18 +122,14 @@ contract GrantRoleTests is CapAutomatorUnitTestBase {
     }
 
     function test_grantRole_updateRole_noAuth() public {
-        address notAdmin   = makeAddr("notAdmin");
-        address newUpdater = makeAddr("newUpdater");
-
-        vm.prank(notAdmin);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                notAdmin,
+                address(this),
                 DEFAULT_ADMIN_ROLE
             )
         );
-        capAutomator.grantRole(UPDATE_ROLE, newUpdater);
+        capAutomator.grantRole(UPDATE_ROLE, makeAddr("newUpdater"));
     }
 
     function test_grantRole_updateRole() public {
@@ -159,7 +148,6 @@ contract GrantRoleTests is CapAutomatorUnitTestBase {
 contract RenounceRoleTests is CapAutomatorUnitTestBase {
 
     function test_renounceAdminRole_noAuth() public {
-        vm.prank(makeAddr("notAdmin"));
         vm.expectRevert(IAccessControl.AccessControlBadConfirmation.selector);
         capAutomator.renounceRole(DEFAULT_ADMIN_ROLE, admin);
     }
@@ -174,7 +162,6 @@ contract RenounceRoleTests is CapAutomatorUnitTestBase {
     }
 
     function test_renounceUpdateRole_noAuth() public {
-        vm.prank(makeAddr("notUpdater"));
         vm.expectRevert(IAccessControl.AccessControlBadConfirmation.selector); 
         capAutomator.renounceRole(UPDATE_ROLE, updater1);
     }
@@ -193,13 +180,10 @@ contract RenounceRoleTests is CapAutomatorUnitTestBase {
 contract RevokeRoleTests is CapAutomatorUnitTestBase {
 
     function test_revokeAdminRole_noAuth() public {
-        address notAdmin = makeAddr("notAdmin");
-
-        vm.prank(notAdmin);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                notAdmin,
+                address(this),
                 DEFAULT_ADMIN_ROLE
             )
         );
@@ -211,6 +195,7 @@ contract RevokeRoleTests is CapAutomatorUnitTestBase {
 
         vm.prank(admin);
         capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
+
         assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), true);
 
         vm.prank(admin);
@@ -225,21 +210,16 @@ contract RevokeRoleTests is CapAutomatorUnitTestBase {
     }
 
     function test_revokeUpdateRole_noAuth() public {
-        address notAdmin = makeAddr("notAdmin");
-
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), true);
-
-        vm.prank(notAdmin);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                notAdmin,
+                address(this),
                 DEFAULT_ADMIN_ROLE
             )
         );
         capAutomator.revokeRole(UPDATE_ROLE, updater1);
 
-        // self revoking role
+        // Self revoking role
         vm.prank(updater1);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -357,11 +337,10 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
 contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setSupplyCapConfig_noAuth() public {
-        vm.prank(makeAddr("notAdmin"));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                makeAddr("notAdmin"),
+                address(this),
                 DEFAULT_ADMIN_ROLE
             )
         );
@@ -611,11 +590,10 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setBorrowCapConfig_noAuth() public {
-        vm.prank(makeAddr("notAdmin"));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                makeAddr("notAdmin"),
+                address(this),
                 DEFAULT_ADMIN_ROLE
             )
         );
@@ -866,15 +844,13 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 contract RemoveSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_removeSupplyCapConfig_noAuth() public {
-        vm.prank(makeAddr("notAdmin"));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                makeAddr("notAdmin"),
+                address(this),
                 DEFAULT_ADMIN_ROLE
             )
         );
-
         capAutomator.removeSupplyCapConfig(asset);
     }
 
@@ -936,11 +912,10 @@ contract RemoveSupplyCapConfigTests is CapAutomatorUnitTestBase {
 contract RemoveBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_removeBorrowCapConfig_noAuth() public {
-        vm.prank(makeAddr("notAdmin"));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                makeAddr("notAdmin"),
+                address(this),
                 DEFAULT_ADMIN_ROLE
             )
         );
@@ -1046,6 +1021,7 @@ contract CalculateNewCapTests is Test {
             1_900,
             2_000
         );
+
         assertEq(newCap, 2_400);
     }
 
@@ -1061,6 +1037,7 @@ contract CalculateNewCapTests is Test {
             1_900,
             2_000
         );
+
         assertEq(newCap, 2_000);
     }
 
@@ -1077,6 +1054,7 @@ contract CalculateNewCapTests is Test {
             1_900,
             2_000
         );
+
         assertEq(newCap, 2_400);
 
         newCap = capAutomator._calculateNewCapExternal(
@@ -1090,6 +1068,7 @@ contract CalculateNewCapTests is Test {
             1_900,
             2_000
         );
+
         assertEq(newCap, 2_000);
     }
 
@@ -1105,6 +1084,7 @@ contract CalculateNewCapTests is Test {
             1_500,
             2_000
         );
+
         assertEq(newCap, 2_000);
     }
 
@@ -1120,6 +1100,7 @@ contract CalculateNewCapTests is Test {
             4_800,
             4_900
         );
+
         assertEq(newCap, 5_000);
     }
 
@@ -1135,11 +1116,11 @@ contract CalculateNewCapTests is Test {
             4_800,
             5_200
         );
+
         assertEq(newCap, 5_000);
     }
 
     function test_calculateNewCap_cooldown() public {
-        vm.warp(12 hours);
         uint256 newCap = capAutomator._calculateNewCapExternal(
             CapAutomator.CapConfig({
                 max:              5_000,
@@ -1151,6 +1132,7 @@ contract CalculateNewCapTests is Test {
             1_900,
             2_000
         );
+
         assertEq(newCap, 2_000);
 
         newCap = capAutomator._calculateNewCapExternal(
@@ -1164,6 +1146,7 @@ contract CalculateNewCapTests is Test {
             1_200,
             2_000
         );
+
         assertEq(newCap, 1_700);
 
         vm.warp(24 hours);
@@ -1178,6 +1161,7 @@ contract CalculateNewCapTests is Test {
             1_900,
             2_000
         );
+
         assertEq(newCap, 2_400);
     }
 
@@ -1193,6 +1177,7 @@ contract CalculateNewCapTests is Test {
             4_800,
             5_200
         );
+
         assertEq(newCap, 4_500);
     }
 
@@ -1203,9 +1188,6 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
     function test_execSupply_noAuth() public {
-        vm.roll(900);
-        vm.warp(900_000);
-
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
@@ -1214,17 +1196,16 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        vm.prank(makeAddr("notUpdater"));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                makeAddr("notUpdater"), 
+                address(this), 
                 UPDATE_ROLE
             )
         );
         capAutomator.execSupply(asset);
 
-        // not even role admin can call execSupply
+        // Not even role admin can call execSupply
         vm.prank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1236,10 +1217,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         capAutomator.execSupply(asset);
     }
 
-    function test_execSupply_after_role_revoke() public {
-        vm.roll(900);
-        vm.warp(900_000);
-
+    function test_execSupply_afterRevoke() public {
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
@@ -1252,14 +1230,10 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         capAutomator.execSupply(asset);
 
         // Revoke UPDATE_ROLE from updater1
-
         vm.prank(admin);
         capAutomator.revokeRole(UPDATE_ROLE, updater1);
+
         assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
-
-
-        vm.roll(1000);
-        vm.warp(1000_000);
 
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
@@ -1269,7 +1243,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1278,7 +1252,6 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             )
         );
         capAutomator.execSupply(asset);
-        vm.stopPrank();
     }
 
     function test_execSupply() public {
@@ -1300,20 +1273,22 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
         ) = capAutomator.supplyCapConfigs(asset);
+
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
             1
         );
-        assertEq(capAutomator.execSupply(asset), 7_400);
-        vm.stopPrank();
+        uint256 newCap = capAutomator.execSupply(asset);
+        
+        assertEq(newCap, 7_400);
+
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
         // = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
-
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
         (
@@ -1321,11 +1296,12 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
         ) = capAutomator.supplyCapConfigs(asset);
+
         assertEq(lastUpdateBlockAfter,  900);
         assertEq(lastIncreaseTimeAfter, 900_000);
     }
 
-    function test_execSupply_multiple_updaters() public {
+    function test_execSupply_multipleUpdaters() public {
         vm.roll(900);
         vm.warp(900_000);
 
@@ -1344,20 +1320,22 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
         ) = capAutomator.supplyCapConfigs(asset);
+
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
             1
         );
-        assertEq(capAutomator.execSupply(asset), 7_400);
-        vm.stopPrank();
+        uint256 newCap = capAutomator.execSupply(asset);
+        
+        assertEq(newCap, 7_400);
+
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
         // = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
-
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
         (
@@ -1387,20 +1365,22 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             lastUpdateBlockBefore,
             lastIncreaseTimeBefore
         ) = capAutomator.supplyCapConfigs(asset);
+
         assertEq(lastUpdateBlockBefore,  900);
         assertEq(lastIncreaseTimeBefore, 900_000);
         
-        vm.startPrank(updater2);
+        vm.prank(updater2);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_900))),
             1
         );
-        assertEq(capAutomator.execSupply(asset), 7_900);
-        vm.stopPrank();
+        newCap = capAutomator.execSupply(asset);
+
+        assertEq(newCap, 7_900);
+
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
         // = (5700 + 50) * 1.2 + 1000 = 6900 + 1000 = 7900
-
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_900);
 
         (
@@ -1408,6 +1388,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             lastUpdateBlockAfter,
             lastIncreaseTimeAfter
         ) = capAutomator.supplyCapConfigs(asset);
+
         assertEq(lastUpdateBlockAfter,  1800);
         assertEq(lastIncreaseTimeAfter, 1800_000);
     }
@@ -1421,7 +1402,6 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         mockPool.__setATokenScaledTotalSupply(4_500e6);
         mockPool.__setAccruedToTreasury(100e6);
         mockPool.__setLiquidityIndex(1.5e27);
-        // (aToken. scaledTotalSupply + accruedToTreasury) * liquidityIndex = 6_900e6
 
         vm.prank(admin);
         capAutomator.setSupplyCapConfig({
@@ -1438,20 +1418,22 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
         ) = capAutomator.supplyCapConfigs(asset);
+
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
         
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
             1
         );
-        assertEq(capAutomator.execSupply(asset), 7_400);
-        vm.stopPrank();
+        uint256 newCap = capAutomator.execSupply(asset);
+
+        assertEq(newCap, 7_400);
+
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
         // = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
-
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
         (
@@ -1459,6 +1441,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
         ) = capAutomator.supplyCapConfigs(asset);
+
         assertEq(lastUpdateBlockAfter,  300);
         assertEq(lastIncreaseTimeAfter, 300_000);
     }
@@ -1474,17 +1457,18 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_000))),
             0
         );
-        assertEq(capAutomator.execSupply(asset), 7_000);
-        vm.stopPrank();
+        uint256 newCap = capAutomator.execSupply(asset);
+
+        assertEq(newCap, 7_000);
+
         // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
         // = (5700 + 50) * 1.2 + 100 = 6900 + 100 = 7000
-
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
     }
 
@@ -1499,14 +1483,15 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(2_000))),
             1
         );
-        assertEq(capAutomator.execSupply(asset), 2_000);
-        vm.stopPrank();
+        uint256 newCap = capAutomator.execSupply(asset);
+
+        assertEq(newCap, 2_000);
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 2_000);
     }
@@ -1518,9 +1503,6 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
     function test_execBorrow_noAuth() public {
-        vm.roll(100);
-        vm.warp(100_000);
-
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
@@ -1529,19 +1511,17 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        vm.startPrank(makeAddr("notUpdater"));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                makeAddr("notUpdater"),
+                address(this),
                 UPDATE_ROLE
             )
         );
         capAutomator.execBorrow(asset);
-        vm.stopPrank();
 
-        // not even role admin can call execBorrow
-        vm.startPrank(admin);
+        // Not even role admin can call execBorrow
+        vm.prank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1550,13 +1530,9 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             )
         );
         capAutomator.execBorrow(asset);
-        vm.stopPrank();
     }
 
-    function test_execBorrow_after_role_revoke() public {
-        vm.roll(100);
-        vm.warp(100_000);
-
+    function test_execBorrow_afterRevoke() public {
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
             asset:            asset,
@@ -1571,10 +1547,8 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         // Revoke UPDATE_ROLE from updater1
         vm.prank(admin);
         capAutomator.revokeRole(UPDATE_ROLE, updater1);
-        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
 
-        vm.roll(200);
-        vm.warp(200_000);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
 
         vm.prank(admin);
         capAutomator.setBorrowCapConfig({
@@ -1584,7 +1558,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             increaseCooldown: 0
         });
 
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
@@ -1593,7 +1567,6 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             )
         );
         capAutomator.execBorrow(asset);
-        vm.stopPrank();
     }
 
     function test_execBorrow() public {
@@ -1615,18 +1588,19 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
         ) = capAutomator.borrowCapConfigs(asset);
+
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
             1
         );
-        assertEq(capAutomator.execBorrow(asset), 4_400);
-        vm.stopPrank();
-        // totalDebt + gap = 3900 + 500 = 4400
+        uint256 newCap = capAutomator.execBorrow(asset);
+
+        assertEq(newCap, 4_400); // totalDebt + gap = 3900 + 500 = 4400
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
@@ -1635,11 +1609,12 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
         ) = capAutomator.borrowCapConfigs(asset);
+
         assertEq(lastUpdateBlockAfter,  100);
         assertEq(lastIncreaseTimeAfter, 100_000);
     }
 
-    function test_execBorrow_multiple_updaters() public {
+    function test_execBorrow_multipleUpdaters() public {
         vm.roll(100);
         vm.warp(100_000);
 
@@ -1658,26 +1633,28 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
         ) = capAutomator.borrowCapConfigs(asset);
+
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.startPrank(updater1);
-        vm.expectCall(
-            address(mockPoolConfigurator),
-            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
-            1
-        );
-        assertEq(capAutomator.execBorrow(asset), 4_400);
-        vm.stopPrank();
-        // totalDebt + gap = 3900 + 500 = 4400
+        vm.prank(updater1);  
+        vm.expectCall(  
+            address(mockPoolConfigurator),  
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),  
+            1  
+        );  
+        uint256 newCap = capAutomator.execBorrow(asset);  
 
-        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
+        assertEq(newCap, 4_400);  // totalDebt + gap = 3900 + 500 = 4400  
+        
+        assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);  
 
         (
             ,,,
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
         ) = capAutomator.borrowCapConfigs(asset);
+
         assertEq(lastUpdateBlockAfter,  100);
         assertEq(lastIncreaseTimeAfter, 100_000);
 
@@ -1699,18 +1676,19 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             lastUpdateBlockBefore,
             lastIncreaseTimeBefore
         ) = capAutomator.borrowCapConfigs(asset);
+
         assertEq(lastUpdateBlockBefore,  100);
         assertEq(lastIncreaseTimeBefore, 100_000);
 
-        vm.startPrank(updater2);
+        vm.prank(updater2);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_900))),
             1
         );
-        assertEq(capAutomator.execBorrow(asset), 4_900);
-        vm.stopPrank();
-        // totalDebt + gap = 3900 + 1000 = 4900
+        newCap = capAutomator.execBorrow(asset);
+
+        assertEq(newCap, 4_900); // totalDebt + gap = 3900 + 1000 = 4900
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_900);
 
@@ -1719,6 +1697,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             lastUpdateBlockAfter,
             lastIncreaseTimeAfter
         ) = capAutomator.borrowCapConfigs(asset);
+
         assertEq(lastUpdateBlockAfter,  200);
         assertEq(lastIncreaseTimeAfter, 200_000);
     }
@@ -1745,18 +1724,19 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             uint48 lastUpdateBlockBefore,
             uint48 lastIncreaseTimeBefore
         ) = capAutomator.borrowCapConfigs(asset);
+
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
             1
         );
-        assertEq(capAutomator.execBorrow(asset), 4_400);
-        vm.stopPrank();
-        // totalDebt + gap = 3900 + 500 = 4400
+        uint256 newCap = capAutomator.execBorrow(asset);
+
+        assertEq(newCap, 4_400); // totalDebt + gap = 3900 + 500 = 4400
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
@@ -1765,6 +1745,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
             uint48 lastUpdateBlockAfter,
             uint48 lastIncreaseTimeAfter
         ) = capAutomator.borrowCapConfigs(asset);
+
         assertEq(lastUpdateBlockAfter,  200);
         assertEq(lastIncreaseTimeAfter, 200_000);
     }
@@ -1780,15 +1761,15 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))), 
             0
         );
-        assertEq(capAutomator.execBorrow(asset), 4_000);
-        vm.stopPrank();
-        // totalDebt + gap = 3900 + 100 = 4000
+        uint256 newCap = capAutomator.execBorrow(asset);
+
+        assertEq(newCap, 4_000); // totalDebt + gap = 3900 + 100 = 4000
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
     }
@@ -1804,14 +1785,15 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
         
-        vm.startPrank(updater1);
+        vm.prank(updater1);
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(1_000))),
             1
         );
-        assertEq(capAutomator.execBorrow(asset), 1_000);
-        vm.stopPrank();
+        uint256 newCap = capAutomator.execBorrow(asset);
+
+        assertEq(newCap, 1_000);
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 1_000);
     }
@@ -1825,9 +1807,6 @@ contract ExecTests is CapAutomatorUnitTestBase {
     function test_exec_noAuth() public {
         mockPool.__setSupplyCap(7_000);
         mockPool.__setBorrowCap(4_000);
-
-        vm.roll(500);
-        vm.warp(500_000);
 
         vm.startPrank(admin);
         capAutomator.setSupplyCapConfig({
@@ -1844,17 +1823,16 @@ contract ExecTests is CapAutomatorUnitTestBase {
         });
         vm.stopPrank();
 
-        vm.prank(makeAddr("notUpdater"));
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAccessControl.AccessControlUnauthorizedAccount.selector,
-                makeAddr("notUpdater"),
+                address(this),
                 UPDATE_ROLE
             )
         );
         capAutomator.exec(asset);
 
-        // not even role admin can call exec
+        // Not even role admin can call exec
         vm.prank(admin);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1866,12 +1844,9 @@ contract ExecTests is CapAutomatorUnitTestBase {
         capAutomator.exec(asset);
     }
 
-    function test_exec_after_role_revoke() public {
+    function test_exec_afterRevoke() public {
         mockPool.__setSupplyCap(7_000);
         mockPool.__setBorrowCap(4_000);
-
-        vm.roll(500);
-        vm.warp(500_000);
 
         vm.startPrank(admin);
         capAutomator.setSupplyCapConfig({
@@ -1892,13 +1867,10 @@ contract ExecTests is CapAutomatorUnitTestBase {
         capAutomator.exec(asset);
 
         // Revoke UPDATE_ROLE from updater1
-
         vm.prank(admin);
         capAutomator.revokeRole(UPDATE_ROLE, updater1);
+        
         assertEq(capAutomator.hasRole(UPDATE_ROLE, updater1), false);
-
-        vm.roll(1000);
-        vm.warp(1000_000);
 
         vm.startPrank(admin);
         capAutomator.setSupplyCapConfig({
@@ -1930,9 +1902,6 @@ contract ExecTests is CapAutomatorUnitTestBase {
         mockPool.__setSupplyCap(7_000);
         mockPool.__setBorrowCap(4_000);
 
-        vm.roll(500);
-        vm.warp(500_000);
-
         vm.startPrank(admin);
         capAutomator.setSupplyCapConfig({
             asset:            asset,
@@ -1956,30 +1925,28 @@ contract ExecTests is CapAutomatorUnitTestBase {
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))),
             1
         );
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
-        // = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
+
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))),
             1
         );
-        // totalDebt + gap = 3900 + 300 = 4200
+        
         vm.prank(updater1);
         ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
-
+        
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
         assertEq(newSupplyCap, 7_300);
-        assertEq(newBorrowCap, 4_200);
+        assertEq(newBorrowCap, 4_200); // totalDebt + gap = 3900 + 300 = 4200
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_300);
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
     }
 
-    function test_exec_multiple_updaters() public {
+    function test_exec_multipleUpdaters() public {
         mockPool.__setSupplyCap(7_000);
         mockPool.__setBorrowCap(4_000);
-
-        vm.roll(500);
-        vm.warp(500_000);
 
         vm.startPrank(admin);
         capAutomator.setSupplyCapConfig({
@@ -2004,19 +1971,20 @@ contract ExecTests is CapAutomatorUnitTestBase {
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))),
             1
         );
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
-        // = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
+        
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))),
             1
         );
-        // totalDebt + gap = 3900 + 300 = 4200
+        
         vm.prank(updater1);
         ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
 
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
         assertEq(newSupplyCap, 7_300);
-        assertEq(newBorrowCap, 4_200);
+        assertEq(newBorrowCap, 4_200); // totalDebt + gap = 3900 + 300 = 4200
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_300);
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
@@ -2047,19 +2015,20 @@ contract ExecTests is CapAutomatorUnitTestBase {
             abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_100))),
             1
         );
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
-        // = (5700 + 50) * 1.2 + 200 = 6900 + 200 = 7100
+       
         vm.expectCall(
             address(mockPoolConfigurator),
             abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))),
             1
         );
-        // totalDebt + gap = 3900 + 100 = 4000
+
         vm.prank(updater2);
         ( newSupplyCap, newBorrowCap ) = capAutomator.exec(asset);
 
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap
+        // = (5700 + 50) * 1.2 + 200 = 6900 + 200 = 7100
         assertEq(newSupplyCap, 7_100);
-        assertEq(newBorrowCap, 4_000);
+        assertEq(newBorrowCap, 4_000);  // totalDebt + gap = 3900 + 100 = 4000
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_100);
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
@@ -2227,8 +2196,7 @@ contract EventTests is CapAutomatorUnitTestBase {
 
         vm.prank(updater1);
         vm.expectEmit(address(capAutomator));
-        emit UpdateBorrowCap(asset, 4_000, 4_200);
-        // totalDebt + gap = 3900 + 300 = 4200
+        emit UpdateBorrowCap(asset, 4_000, 4_200); // totalDebt + gap = 3900 + 300 = 4200
         capAutomator.exec(asset);
     }
 

--- a/test/CapAutomator.t.sol
+++ b/test/CapAutomator.t.sol
@@ -24,9 +24,9 @@ contract CapAutomatorUnitTestBase is Test {
     MockPool                  public mockPool;
     MockPoolConfigurator      public mockPoolConfigurator;
 
-    address public admin;
+    address   public admin;
     address[] public updaters;
-    address public asset;
+    address   public asset;
 
     CapAutomator public capAutomator;
 
@@ -34,14 +34,17 @@ contract CapAutomatorUnitTestBase is Test {
     bytes32 public UPDATE_ROLE;
 
     function setUp() public {
-        admin = makeAddr("admin");
+        admin   = makeAddr("admin");
+        asset   = makeAddr("asset");
+
         updaters.push(makeAddr("updater-1"));
         updaters.push(makeAddr("updater-2"));
-        asset = makeAddr("asset");
 
         mockPool                  = new MockPool();
         mockPoolConfigurator      = new MockPoolConfigurator(mockPool);
-        mockPoolAddressesProvider = new MockPoolAddressesProvider(address(mockPool), address(mockPoolConfigurator));
+        mockPoolAddressesProvider = new MockPoolAddressesProvider(
+            address(mockPool), address(mockPoolConfigurator)
+        );
 
         mockPool.__setSupplyCap(7_000);
 
@@ -57,10 +60,10 @@ contract CapAutomatorUnitTestBase is Test {
         mockPool.__setTotalDebt(3_900e18);
 
         vm.startPrank(admin);
-        capAutomator = new CapAutomator(address(mockPoolAddressesProvider), updaters[0]);
+        capAutomator = new CapAutomator(address(mockPoolAddressesProvider), admin, updaters[0]);
 
-        DEFAULT_ADMIN_ROLE = capAutomator.DEFAULT_ADMIN_ROLE();
-        UPDATE_ROLE = capAutomator.UPDATE_ROLE();
+        DEFAULT_ADMIN_ROLE  = capAutomator.DEFAULT_ADMIN_ROLE();
+        UPDATE_ROLE         = capAutomator.UPDATE_ROLE();
 
         capAutomator.grantRole(UPDATE_ROLE, updaters[1]);
         vm.stopPrank();
@@ -73,14 +76,21 @@ contract ConstructorTests is CapAutomatorUnitTestBase {
     function test_constructor() public {
         assertEq(address(capAutomator.pool()),             address(mockPool));
         assertEq(address(capAutomator.poolConfigurator()), address(mockPoolConfigurator));
-        assertTrue(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin));
-        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
-        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[1]));
+
+        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin),   true);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]),    true);
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[1]),    true);
     }
 
-    function test_constructor_zeroUpdater() public {
+    function test_constructor_zeroAddress() public {
         vm.expectRevert("CapAutomator/zero-address");
-        new CapAutomator(address(mockPoolAddressesProvider), address(0));
+        new CapAutomator(address(mockPoolAddressesProvider), address(0), updaters[0]);
+
+        vm.expectRevert("CapAutomator/zero-address");
+        new CapAutomator(address(mockPoolAddressesProvider), admin, address(0));
+
+        vm.expectRevert("CapAutomator/zero-address");
+        new CapAutomator(address(mockPoolAddressesProvider), address(0), address(0));
     }
 
 }
@@ -92,19 +102,25 @@ contract GrantRoleTests is CapAutomatorUnitTestBase {
         address newAdmin = makeAddr("newAdmin");
 
         vm.prank(notAdmin);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, notAdmin, DEFAULT_ADMIN_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, 
+                notAdmin, 
+                DEFAULT_ADMIN_ROLE
+            )
+        );
         capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
     }
 
     function test_grantRole_defaultAdminRole() public {
         address newAdmin = makeAddr("newAdmin");
 
-        assertFalse(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin));
+        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), false);
 
         vm.prank(admin);
         capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
 
-        assertTrue(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin));
+        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), true);
     }
 
     function test_grantRole_updateRole_noAuth() public {
@@ -112,19 +128,25 @@ contract GrantRoleTests is CapAutomatorUnitTestBase {
         address newUpdater = makeAddr("newUpdater");
 
         vm.prank(notAdmin);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, notAdmin, DEFAULT_ADMIN_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, 
+                notAdmin, 
+                DEFAULT_ADMIN_ROLE
+            )
+        );
         capAutomator.grantRole(UPDATE_ROLE, newUpdater);
     }
 
     function test_grantRole_updateRole() public {
         address newUpdater = makeAddr("newUpdater");
 
-        assertFalse(capAutomator.hasRole(UPDATE_ROLE, newUpdater));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, newUpdater), false);
 
         vm.prank(admin);
         capAutomator.grantRole(UPDATE_ROLE, newUpdater);
 
-        assertTrue(capAutomator.hasRole(UPDATE_ROLE, newUpdater));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, newUpdater), true);
     }
 
 }
@@ -138,12 +160,12 @@ contract RenounceRoleTests is CapAutomatorUnitTestBase {
     }
 
     function test_renounceAdminRole() public {
-        assertTrue(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin));
+        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin), true);
 
         vm.prank(admin);
         capAutomator.renounceRole(DEFAULT_ADMIN_ROLE, admin);
 
-        assertFalse(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin));
+        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin), false);
     }
 
     function test_renounceUpdateRole_badConfirmation() public {
@@ -153,12 +175,12 @@ contract RenounceRoleTests is CapAutomatorUnitTestBase {
     }
 
     function test_renounceUpdateRole() public {
-        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
 
         vm.prank(updaters[0]);
         capAutomator.renounceRole(UPDATE_ROLE, updaters[0]);
 
-        assertFalse(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), false);
     }
 
 }
@@ -169,7 +191,13 @@ contract RevokeRoleTests is CapAutomatorUnitTestBase {
         address notAdmin = makeAddr("notAdmin");
 
         vm.prank(notAdmin);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, notAdmin, DEFAULT_ADMIN_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                notAdmin, 
+                DEFAULT_ADMIN_ROLE
+            )
+        );
         capAutomator.revokeRole(DEFAULT_ADMIN_ROLE, admin);
     }
 
@@ -178,41 +206,53 @@ contract RevokeRoleTests is CapAutomatorUnitTestBase {
 
         vm.prank(admin);
         capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
-        assertTrue(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin));
+        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), true);
 
         vm.prank(admin);
         capAutomator.revokeRole(DEFAULT_ADMIN_ROLE, newAdmin);
 
-        assertFalse(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin));
+        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, newAdmin), false);
 
         vm.prank(admin);
         capAutomator.revokeRole(DEFAULT_ADMIN_ROLE, admin);
 
-        assertFalse(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin));
+        assertEq(capAutomator.hasRole(DEFAULT_ADMIN_ROLE, admin), false);
     }
 
     function test_revokeUpdateRole_noAuth() public {
         address notAdmin = makeAddr("notAdmin");
 
-        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
 
         vm.prank(notAdmin);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, notAdmin, DEFAULT_ADMIN_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, 
+                notAdmin, 
+                DEFAULT_ADMIN_ROLE
+            )
+        );
         capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
 
         // self revoking role
         vm.prank(updaters[0]);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, updaters[0], DEFAULT_ADMIN_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, 
+                updaters[0], 
+                DEFAULT_ADMIN_ROLE
+            )
+        );
         capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
     }
 
     function test_revokeUpdateRole() public {
-        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
 
         vm.prank(admin);
         capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
 
-        assertFalse(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), false);
     }
 
 }
@@ -255,8 +295,8 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
         vm.prank(admin);
         capAutomator.grantRole(DEFAULT_ADMIN_ROLE, newAdmin);
 
-        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 2);
-        assertEq(capAutomator.getRoleMember(DEFAULT_ADMIN_ROLE, 1), newAdmin);
+        assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE),   2);
+        assertEq(capAutomator.getRoleMember(DEFAULT_ADMIN_ROLE, 1),     newAdmin);
 
         address newUpdater = makeAddr("newUpdater");
 
@@ -265,8 +305,8 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
         vm.prank(admin);
         capAutomator.grantRole(UPDATE_ROLE, newUpdater);
 
-        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 3);
-        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 2), newUpdater);
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE),  3);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 2),    newUpdater);
     }
 
     function test_getRoleMemberCount_afterRevoke() public {
@@ -276,8 +316,8 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
         vm.prank(admin);
         capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
 
-        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 1);
-        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0), updaters[1]);
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE),  1);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0),    updaters[1]);
 
         // Test revoking DEFAULT_ADMIN_ROLE
         assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
@@ -295,8 +335,8 @@ contract AccessControlEnumerableRolesTests is CapAutomatorUnitTestBase {
         vm.prank(updaters[0]);
         capAutomator.renounceRole(UPDATE_ROLE, updaters[0]);
 
-        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE), 1);
-        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0), updaters[1]);
+        assertEq(capAutomator.getRoleMemberCount(UPDATE_ROLE),  1);
+        assertEq(capAutomator.getRoleMember(UPDATE_ROLE, 0),    updaters[1]);
 
         // Test renouncing DEFAULT_ADMIN_ROLE
         assertEq(capAutomator.getRoleMemberCount(DEFAULT_ADMIN_ROLE), 1);
@@ -313,7 +353,13 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setSupplyCapConfig_noAuth() public {
         vm.prank(makeAddr("notAdmin"));
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notAdmin"), DEFAULT_ADMIN_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, 
+                makeAddr("notAdmin"), 
+                DEFAULT_ADMIN_ROLE
+            )
+        );
         capAutomator.setSupplyCapConfig(
             asset,
             10_000,
@@ -514,7 +560,11 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        ( ,,, uint48 lastUpdateBlock, uint48 lastIncreaseTime ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,, 
+            uint48 lastUpdateBlock,
+            uint48 lastIncreaseTime
+        ) = capAutomator.supplyCapConfigs(asset);
 
         assertEq(lastUpdateBlock,  0);
         assertEq(lastIncreaseTime, 0);
@@ -524,7 +574,11 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
         vm.prank(updaters[0]);
         capAutomator.exec(asset);
 
-        ( ,,, uint48 postExecUpdateBlock, uint48 postExecIncreaseTime ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,, 
+            uint48 postExecUpdateBlock,
+            uint48 postExecIncreaseTime
+        ) = capAutomator.supplyCapConfigs(asset);
 
         assertEq(postExecUpdateBlock,  120_000);
         assertEq(postExecIncreaseTime, 12 hours);
@@ -537,7 +591,11 @@ contract SetSupplyCapConfigTests is CapAutomatorUnitTestBase {
             24 hours
         );
 
-        ( ,,, uint48 postReconfigUpdateBlock, uint48 postReconfigIncreaseTime ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,, 
+            uint48 postReconfigUpdateBlock,
+            uint48 postReconfigIncreaseTime
+        ) = capAutomator.supplyCapConfigs(asset);
 
         assertEq(postReconfigUpdateBlock,  postExecUpdateBlock);
         assertEq(postReconfigIncreaseTime, postExecIncreaseTime);
@@ -549,7 +607,13 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_setBorrowCapConfig_noAuth() public {
         vm.prank(makeAddr("notAdmin"));
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notAdmin"), DEFAULT_ADMIN_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                makeAddr("notAdmin"),
+                DEFAULT_ADMIN_ROLE
+            )
+        );
         capAutomator.setBorrowCapConfig(
             asset,
             10_000,
@@ -750,7 +814,11 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             12 hours
         );
 
-        ( ,,, uint48 lastUpdateBlock, uint48 lastIncreaseTime ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,, 
+            uint48 lastUpdateBlock,
+            uint48 lastIncreaseTime
+        ) = capAutomator.borrowCapConfigs(asset);
 
         assertEq(lastUpdateBlock,  0);
         assertEq(lastIncreaseTime, 0);
@@ -760,7 +828,11 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
         vm.prank(updaters[0]);
         capAutomator.exec(asset);
 
-        ( ,,, uint48 postExecUpdateBlock, uint48 postExecIncreaseTime ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 postExecUpdateBlock,
+            uint48 postExecIncreaseTime
+        ) = capAutomator.borrowCapConfigs(asset);
 
         assertEq(postExecUpdateBlock,  600);
         assertEq(postExecIncreaseTime, 12 hours);
@@ -773,7 +845,11 @@ contract SetBorrowCapConfigTests is CapAutomatorUnitTestBase {
             24 hours
         );
 
-        ( ,,, uint48 postReconfigUpdateBlock, uint48 postReconfigIncreaseTime ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 postReconfigUpdateBlock,
+            uint48 postReconfigIncreaseTime
+        ) = capAutomator.borrowCapConfigs(asset);
 
         assertEq(postReconfigUpdateBlock,  postExecUpdateBlock);
         assertEq(postReconfigIncreaseTime, postExecIncreaseTime);
@@ -785,7 +861,13 @@ contract RemoveSupplyCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_removeSupplyCapConfig_noAuth() public {
         vm.prank(makeAddr("notAdmin"));
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notAdmin"), DEFAULT_ADMIN_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                makeAddr("notAdmin"),
+                DEFAULT_ADMIN_ROLE
+            )
+        );
 
         capAutomator.removeSupplyCapConfig(asset);
     }
@@ -849,7 +931,13 @@ contract RemoveBorrowCapConfigTests is CapAutomatorUnitTestBase {
 
     function test_removeBorrowCapConfig_noAuth() public {
         vm.prank(makeAddr("notAdmin"));
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notAdmin"), DEFAULT_ADMIN_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                makeAddr("notAdmin"),
+                DEFAULT_ADMIN_ROLE
+            )
+        );
         capAutomator.removeBorrowCapConfig(asset);
     }
 
@@ -926,10 +1014,17 @@ contract CalculateNewCapTests is Test {
 
         mockPool                  = new MockPool();
         mockPoolConfigurator      = new MockPoolConfigurator(mockPool);
-        mockPoolAddressesProvider = new MockPoolAddressesProvider(address(mockPool), address(mockPoolConfigurator));
+        mockPoolAddressesProvider = new MockPoolAddressesProvider(
+            address(mockPool),
+            address(mockPoolConfigurator)
+        );
 
         vm.startPrank(admin);
-        capAutomator = new CapAutomatorHarness(address(mockPoolAddressesProvider), updaters[0]);
+        capAutomator = new CapAutomatorHarness(
+            address(mockPoolAddressesProvider),
+            admin,
+            updaters[0]
+        );
         vm.stopPrank();
     }
 
@@ -1115,18 +1210,34 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,, 
+            uint48 lastUpdateBlockBefore,
+            uint48 lastIncreaseTimeBefore
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
         vm.startPrank(makeAddr("notUpdater"));
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notUpdater"), UPDATE_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                makeAddr("notUpdater"), 
+                UPDATE_ROLE
+            )
+        );
         capAutomator.execSupply(asset);
         vm.stopPrank();
 
         // not even role admin can call execSupply
         vm.startPrank(admin);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, UPDATE_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                admin,
+                UPDATE_ROLE
+            )
+        );
         capAutomator.execSupply(asset);
         vm.stopPrank();
     }
@@ -1145,27 +1256,41 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockBefore,
+            uint48 lastIncreaseTimeBefore
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap,(asset, uint256(7_400))), 
+            1
+        );
         assertEq(capAutomator.execSupply(asset), 7_400);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 
+        // 6900 + 500 = 7400
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
-        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockAfter,
+            uint48 lastIncreaseTimeAfter
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockAfter,  900);
         assertEq(lastIncreaseTimeAfter, 900_000);
 
         // Revoke UPDATE_ROLE from updaters[0]
-        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
         vm.prank(admin);
         capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
-        assertFalse(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), false);
 
 
         vm.roll(1000);
@@ -1181,12 +1306,22 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
-        ( ,,, lastUpdateBlockBefore, lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            lastUpdateBlockBefore,
+            lastIncreaseTimeBefore
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  900);
         assertEq(lastIncreaseTimeBefore, 900_000);
 
         vm.startPrank(updaters[0]);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, updaters[0], UPDATE_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                updaters[0],
+                UPDATE_ROLE
+            )
+        );
         capAutomator.execSupply(asset);
         vm.stopPrank();
     }
@@ -1205,19 +1340,32 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockBefore,
+            uint48 lastIncreaseTimeBefore
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
+            1
+        );
         assertEq(capAutomator.execSupply(asset), 7_400);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 
+        // 6900 + 500 = 7400
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
-        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockAfter,
+            uint48 lastIncreaseTimeAfter
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockAfter,  900);
         assertEq(lastIncreaseTimeAfter, 900_000);
     }
@@ -1236,19 +1384,33 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockBefore,
+            uint48 lastIncreaseTimeBefore
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
+            1
+        );
         assertEq(capAutomator.execSupply(asset), 7_400);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 
+        // 6900 + 500 = 7400
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
-        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockAfter,
+            uint48 lastIncreaseTimeAfter
+        ) = capAutomator.supplyCapConfigs(asset);
+
         assertEq(lastUpdateBlockAfter,  900);
         assertEq(lastIncreaseTimeAfter, 900_000);
 
@@ -1265,19 +1427,32 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
-        ( ,,, lastUpdateBlockBefore, lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            lastUpdateBlockBefore,
+            lastIncreaseTimeBefore
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  900);
         assertEq(lastIncreaseTimeBefore, 900_000);
         
         vm.startPrank(updaters[1]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_900))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap,(asset, uint256(7_900))),
+            1
+        );
         assertEq(capAutomator.execSupply(asset), 7_900);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 1000 = 6900 + 1000 = 7900
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 1000
+        // 6900 + 1000 = 7900
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_900);
 
-        ( ,,, lastUpdateBlockAfter, lastIncreaseTimeAfter ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            lastUpdateBlockAfter,
+            lastIncreaseTimeAfter
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockAfter,  1800);
         assertEq(lastIncreaseTimeAfter, 1800_000);
     }
@@ -1303,19 +1478,32 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
-        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockBefore,
+            uint48 lastIncreaseTimeBefore
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
         
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_400))),
+            1
+        );
         assertEq(capAutomator.execSupply(asset), 7_400);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 = 6900 + 500 = 7400
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 500 
+        // 6900 + 500 = 7400
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_400);
 
-        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.supplyCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockAfter,
+            uint48 lastIncreaseTimeAfter
+        ) = capAutomator.supplyCapConfigs(asset);
         assertEq(lastUpdateBlockAfter,  300);
         assertEq(lastIncreaseTimeAfter, 300_000);
     }
@@ -1332,10 +1520,15 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_000))), 0);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_000))),
+            0
+        );
         assertEq(capAutomator.execSupply(asset), 7_000);
         vm.stopPrank();
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 100 = 6900 + 100 = 7000
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 100 
+        // 6900 + 100 = 7000
 
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
     }
@@ -1352,7 +1545,11 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
 
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(2_000))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(2_000))),
+            1
+        );
         assertEq(capAutomator.execSupply(asset), 2_000);
         vm.stopPrank();
 
@@ -1379,18 +1576,34 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockBefore,
+            uint48 lastIncreaseTimeBefore
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
         vm.startPrank(makeAddr("notUpdater"));
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notUpdater"), UPDATE_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                makeAddr("notUpdater"),
+                UPDATE_ROLE
+            )
+        );
         capAutomator.execBorrow(asset);
         vm.stopPrank();
 
         // not even role admin can call execBorrow
         vm.startPrank(admin);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, UPDATE_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                admin,
+                UPDATE_ROLE
+            )
+        );
         capAutomator.execBorrow(asset);
         vm.stopPrank();
     }
@@ -1409,27 +1622,39 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockBefore,
+            uint48 lastIncreaseTimeBefore
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
+            1
+        );
         assertEq(capAutomator.execBorrow(asset), 4_400);
         vm.stopPrank();
         // totalDebt + gap = 3900 + 500 = 4400
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
-        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockAfter,
+            uint48 lastIncreaseTimeAfter
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockAfter,  100);
         assertEq(lastIncreaseTimeAfter, 100_000);
 
         // Revoke UPDATE_ROLE from updaters[0]
-        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
         vm.prank(admin);
         capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
-        assertFalse(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), false);
 
         vm.roll(200);
         vm.warp(200_000);
@@ -1444,12 +1669,22 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
-        ( ,,, lastUpdateBlockBefore, lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            lastUpdateBlockBefore,
+            lastIncreaseTimeBefore
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  100);
         assertEq(lastIncreaseTimeBefore, 100_000);
 
         vm.startPrank(updaters[0]);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, updaters[0], UPDATE_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                updaters[0],
+                UPDATE_ROLE
+            )
+        );
         capAutomator.execBorrow(asset);
         vm.stopPrank();
     }
@@ -1468,19 +1703,31 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockBefore,
+            uint48 lastIncreaseTimeBefore
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))), 
+            1
+        );
         assertEq(capAutomator.execBorrow(asset), 4_400);
         vm.stopPrank();
         // totalDebt + gap = 3900 + 500 = 4400
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
-        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockAfter,
+            uint48 lastIncreaseTimeAfter
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockAfter,  100);
         assertEq(lastIncreaseTimeAfter, 100_000);
     }
@@ -1499,19 +1746,31 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockBefore,
+            uint48 lastIncreaseTimeBefore
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
+            1
+        );
         assertEq(capAutomator.execBorrow(asset), 4_400);
         vm.stopPrank();
         // totalDebt + gap = 3900 + 500 = 4400
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
-        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockAfter,
+            uint48 lastIncreaseTimeAfter
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockAfter,  100);
         assertEq(lastIncreaseTimeAfter, 100_000);
 
@@ -1528,19 +1787,31 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
-        ( ,,, lastUpdateBlockBefore, lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            lastUpdateBlockBefore,
+            lastIncreaseTimeBefore
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  100);
         assertEq(lastIncreaseTimeBefore, 100_000);
 
         vm.startPrank(updaters[1]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_900))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_900))), 
+            1
+        );
         assertEq(capAutomator.execBorrow(asset), 4_900);
         vm.stopPrank();
         // totalDebt + gap = 3900 + 1000 = 4900
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_900);
 
-        ( ,,, lastUpdateBlockAfter, lastIncreaseTimeAfter ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            lastUpdateBlockAfter,
+            lastIncreaseTimeAfter
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockAfter,  200);
         assertEq(lastIncreaseTimeAfter, 200_000);
     }
@@ -1562,19 +1833,31 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        ( ,,, uint48 lastUpdateBlockBefore, uint48 lastIncreaseTimeBefore ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockBefore,
+            uint48 lastIncreaseTimeBefore
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockBefore,  0);
         assertEq(lastIncreaseTimeBefore, 0);
 
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_400))),
+            1
+        );
         assertEq(capAutomator.execBorrow(asset), 4_400);
         vm.stopPrank();
         // totalDebt + gap = 3900 + 500 = 4400
 
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_400);
 
-        ( ,,, uint48 lastUpdateBlockAfter, uint48 lastIncreaseTimeAfter ) = capAutomator.borrowCapConfigs(asset);
+        ( 
+            ,,,
+            uint48 lastUpdateBlockAfter,
+            uint48 lastIncreaseTimeAfter
+        ) = capAutomator.borrowCapConfigs(asset);
         assertEq(lastUpdateBlockAfter,  200);
         assertEq(lastIncreaseTimeAfter, 200_000);
     }
@@ -1591,7 +1874,11 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))), 0);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))), 
+            0
+        );
         assertEq(capAutomator.execBorrow(asset), 4_000);
         vm.stopPrank();
         // totalDebt + gap = 3900 + 100 = 4000
@@ -1611,7 +1898,11 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
         
         vm.startPrank(updaters[0]);
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(1_000))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(1_000))), 
+            1
+        );
         assertEq(capAutomator.execBorrow(asset), 1_000);
         vm.stopPrank();
 
@@ -1650,13 +1941,25 @@ contract ExecTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
         vm.startPrank(makeAddr("notUpdater"));
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, makeAddr("notUpdater"), UPDATE_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                makeAddr("notUpdater"),
+                UPDATE_ROLE
+            )
+        );
         capAutomator.exec(asset);
         vm.stopPrank();
 
         // not even role admin can call exec
         vm.startPrank(admin);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, admin, UPDATE_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                admin,
+                UPDATE_ROLE
+            )
+        );
         capAutomator.exec(asset);
         vm.stopPrank();
     }
@@ -1686,9 +1989,18 @@ contract ExecTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))), 1);
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))),
+            1
+        );
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 
+        // 6900 + 400 = 7300
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 
+            1
+        );
         // totalDebt + gap = 3900 + 300 = 4200
         vm.prank(updaters[0]);
         ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
@@ -1700,10 +2012,10 @@ contract ExecTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
 
         // Revoke UPDATE_ROLE from updaters[0]
-        assertTrue(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), true);
         vm.prank(admin);
         capAutomator.revokeRole(UPDATE_ROLE, updaters[0]);
-        assertFalse(capAutomator.hasRole(UPDATE_ROLE, updaters[0]));
+        assertEq(capAutomator.hasRole(UPDATE_ROLE, updaters[0]), false);
 
         vm.roll(1000);
         vm.warp(1000_000);
@@ -1727,7 +2039,13 @@ contract ExecTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
         
         vm.prank(updaters[0]);
-        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, updaters[0], UPDATE_ROLE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                updaters[0],
+                UPDATE_ROLE
+            )
+        );
         capAutomator.exec(asset);
     }
 
@@ -1756,9 +2074,18 @@ contract ExecTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))), 1);
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))), 
+            1
+        );
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 
+        // 6900 + 400 = 7300
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 
+            1
+        );
         // totalDebt + gap = 3900 + 300 = 4200
         vm.prank(updaters[0]);
         ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
@@ -1795,9 +2122,18 @@ contract ExecTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_000);
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_000);
 
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))), 1);
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_300))), 
+            1
+        );
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 
+        // 6900 + 400 = 7300
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_200))), 
+            1
+        );
         // totalDebt + gap = 3900 + 300 = 4200
         vm.prank(updaters[0]);
         ( uint256 newSupplyCap, uint256 newBorrowCap ) = capAutomator.exec(asset);
@@ -1829,9 +2165,18 @@ contract ExecTests is CapAutomatorUnitTestBase {
         assertEq(mockPool.getReserveData(asset).configuration.getSupplyCap(), 7_300);
         assertEq(mockPool.getReserveData(asset).configuration.getBorrowCap(), 4_200);
 
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_100))), 1);
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 200 = 6900 + 200 = 7100
-        vm.expectCall(address(mockPoolConfigurator), abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))), 1);
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setSupplyCap, (asset, uint256(7_100))), 
+            1
+        );
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 200 
+        // 6900 + 200 = 7100
+        vm.expectCall(
+            address(mockPoolConfigurator),
+            abi.encodeCall(IPoolConfigurator.setBorrowCap, (asset, uint256(4_000))),
+            1
+        );
         // totalDebt + gap = 3900 + 100 = 4000
         vm.prank(updaters[1]);
         ( newSupplyCap, newBorrowCap ) = capAutomator.exec(asset);
@@ -1852,8 +2197,18 @@ contract EventTests is CapAutomatorUnitTestBase {
     event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
 
     // CapAutomator events
-    event SetSupplyCapConfig(address indexed asset, uint256 max, uint256 gap, uint256 increaseCooldown);
-    event SetBorrowCapConfig(address indexed asset, uint256 max, uint256 gap, uint256 increaseCooldown);
+    event SetSupplyCapConfig(
+        address indexed asset, 
+        uint256 max, 
+        uint256 gap, 
+        uint256 increaseCooldown
+    );
+    event SetBorrowCapConfig(
+        address indexed asset,
+        uint256 max,
+        uint256 gap,
+        uint256 increaseCooldown
+    );
 
     event RemoveSupplyCapConfig(address indexed asset);
     event RemoveBorrowCapConfig(address indexed asset);
@@ -1979,7 +2334,8 @@ contract EventTests is CapAutomatorUnitTestBase {
         vm.prank(updaters[0]);
         vm.expectEmit(address(capAutomator));
         emit UpdateSupplyCap(asset, 7_000, 7_300);
-        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 = 6900 + 400 = 7300
+        // (scaledTotalSupply + accruedToTreasury) * liquidityIndex + gap = (5700 + 50) * 1.2 + 400 
+        // 6900 + 400 = 7300
         capAutomator.execSupply(asset);
     }
 

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
-import "forge-std/Test.sol";
+import { Test } from "../lib/forge-std/src/Test.sol";
 
-import { IERC20 }         from "openzeppelin-contracts/interfaces/IERC20.sol";
-import { IERC20Metadata } from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
+import { ReserveConfiguration } from "../lib/aave-v3-core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
+import { DataTypes }            from "../lib/aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
+import { WadRayMath }           from "../lib/aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol";
 
-import { ReserveConfiguration } from "aave-v3-core-contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
-import { DataTypes }            from "aave-v3-core-contracts/protocol/libraries/types/DataTypes.sol";
-import { WadRayMath }           from "aave-v3-core-contracts/protocol/libraries/math/WadRayMath.sol";
-import { IACLManager }          from "aave-v3-core-contracts/interfaces/IACLManager.sol";
-import { IPool }                from "aave-v3-core-contracts/interfaces/IPool.sol";
-import { IScaledBalanceToken }  from "aave-v3-core-contracts/interfaces/IScaledBalanceToken.sol";
+import { Ethereum }  from "../lib/spark-address-registry/src/Ethereum.sol";
+import { SparkLend } from "../lib/spark-address-registry/src/SparkLend.sol";
 
-import { Ethereum }  from "spark-address-registry/Ethereum.sol";
-import { SparkLend } from "spark-address-registry/SparkLend.sol";
+import { IACLManagerLike, IPoolLike, IScaledBalanceTokenLike } from "./interfaces/IAAVEV3.sol";
+
+import { IERC20Like } from "./interfaces/Common.sol";
 
 import { CapAutomator } from "../src/CapAutomator.sol";
 
@@ -22,24 +20,24 @@ contract CapAutomatorIntegrationTestsBase is Test {
 
     using WadRayMath for uint256;
 
-    address public constant POOL_ADDRESSES_PROVIDER = SparkLend.POOL_ADDRESSES_PROVIDER;
-    address public constant POOL                    = SparkLend.POOL;
-    address public constant POOL_CONFIG             = SparkLend.POOL_CONFIGURATOR;
-    address public constant DATA_PROVIDER           = SparkLend.PROTOCOL_DATA_PROVIDER;
-    address public constant ACL_MANAGER             = SparkLend.ACL_MANAGER;
-    address public constant SPARK_PROXY             = Ethereum.SPARK_PROXY;
-    address public constant CAP_AUTO_UPDATER        = Ethereum.ALM_RELAYER_MULTISIG;
-    address public constant WETH                    = Ethereum.WETH;
-    address public constant WBTC                    = Ethereum.WBTC;
+    address internal constant POOL_ADDRESSES_PROVIDER = SparkLend.POOL_ADDRESSES_PROVIDER;
+    address internal constant POOL                    = SparkLend.POOL;
+    address internal constant POOL_CONFIG             = SparkLend.POOL_CONFIGURATOR;
+    address internal constant DATA_PROVIDER           = SparkLend.PROTOCOL_DATA_PROVIDER;
+    address internal constant ACL_MANAGER             = SparkLend.ACL_MANAGER;
+    address internal constant SPARK_PROXY             = Ethereum.SPARK_PROXY;
+    address internal constant CAP_AUTO_UPDATER        = Ethereum.ALM_RELAYER_MULTISIG;
+    address internal constant WETH                    = Ethereum.WETH;
+    address internal constant WBTC                    = Ethereum.WBTC;
 
-    address public user;
+    address internal user = makeAddr("user");
 
-    address[] assets;
+    address[] internal assets;
 
-    CapAutomator public capAutomator;
+    CapAutomator internal capAutomator;
 
-    IACLManager aclManager = IACLManager(ACL_MANAGER);
-    IPool       pool       = IPool(POOL);
+    IACLManagerLike internal aclManager = IACLManagerLike(ACL_MANAGER);
+    IPoolLike       internal pool       = IPoolLike(POOL);
 
     function setUp() public {
         vm.createSelectFork(getChain("mainnet").rpcUrl, 18721430);
@@ -51,25 +49,25 @@ contract CapAutomatorIntegrationTestsBase is Test {
         aclManager.addRiskAdmin(address(capAutomator));
 
         assets = pool.getReservesList();
-
-        user = makeAddr("user");
     }
 
-    function currentATokenSupply(
+    function _currentATokenSupply(
         DataTypes.ReserveData memory _reserveData
     ) internal view returns (uint256) {
-        return (
-            IScaledBalanceToken(_reserveData.aTokenAddress).scaledTotalSupply()
-            + uint256(_reserveData.accruedToTreasury)
-        ).rayMul(_reserveData.liquidityIndex)
-        / 10 ** IERC20Metadata(_reserveData.aTokenAddress).decimals();
+        return
+            (
+                IScaledBalanceTokenLike(_reserveData.aTokenAddress).scaledTotalSupply()
+                + _reserveData.accruedToTreasury
+            ).rayMul(_reserveData.liquidityIndex)
+            / 10 ** IERC20Like(_reserveData.aTokenAddress).decimals();
     }
 
     function currentBorrows(
         DataTypes.ReserveData memory _reserveData
     ) internal view returns (uint256) {
-        return IERC20(_reserveData.variableDebtTokenAddress).totalSupply()
-            / 10 ** IERC20Metadata(_reserveData.variableDebtTokenAddress).decimals();
+        return
+            IERC20Like(_reserveData.variableDebtTokenAddress).totalSupply()
+            / 10 ** IERC20Like(_reserveData.variableDebtTokenAddress).decimals();
     }
 
 }
@@ -78,8 +76,8 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
 
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
 
-    function test_E2E_increaseBorrowCap() public {
-        for (uint256 i; i < assets.length; i++) {
+    function test_E2E_increaseBorrowCap() external {
+        for (uint256 i; i < assets.length; ++i) {
             DataTypes.ReserveData memory reserveData = pool.getReserveData(assets[i]);
 
             uint256 preIncreaseBorrowCap = reserveData.configuration.getBorrowCap();
@@ -111,7 +109,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 increaseCooldown: 12 hours
             });
 
-            ( 
+            (
                 ,,,
                 uint48 lastUpdateBlock,
                 uint48 lastIncreaseTime
@@ -123,7 +121,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
-            ( 
+            (
                 ,,,
                 lastUpdateBlock,
                 lastIncreaseTime
@@ -132,22 +130,21 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, block.timestamp);
 
-            uint256 postIncreaseBorrowCap 
+            uint256 postIncreaseBorrowCap
                 = pool.getReserveData(assets[i]).configuration.getBorrowCap();
 
             assertEq(postIncreaseBorrowCap, currentBorrow + newGap);
         }
     }
 
-    function test_E2E_decreaseBorrowCap() public {
-        for (uint256 i; i < assets.length; i++) {
+    function test_E2E_decreaseBorrowCap() external {
+        for (uint256 i; i < assets.length; ++i) {
             DataTypes.ReserveData memory reserveData = pool.getReserveData(assets[i]);
 
             uint256 preDecreaseBorrowCap = reserveData.configuration.getBorrowCap();
+
             // If there is a cap a decrease will be attempted, but if there is no cap, decrease is not possible
-            if (preDecreaseBorrowCap == 0) {
-                continue;
-            }
+            if (preDecreaseBorrowCap == 0) continue;
 
             uint256 currentBorrow        = currentBorrows(reserveData);
             uint256 preDecreaseBorrowGap = preDecreaseBorrowCap - currentBorrow;
@@ -162,7 +159,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 increaseCooldown: 12 hours
             });
 
-            ( 
+            (
                 ,,,
                 uint48 lastUpdateBlock,
                 uint48 lastIncreaseTime
@@ -174,7 +171,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
-            ( 
+            (
                 ,,,
                 lastUpdateBlock,
                 lastIncreaseTime
@@ -183,40 +180,40 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, 0);
 
-            uint256 postDecreaseBorrowCap 
+            uint256 postDecreaseBorrowCap
                 = pool.getReserveData(assets[i]).configuration.getBorrowCap();
 
             assertEq(postDecreaseBorrowCap, currentBorrow + newGap);
 
-            if (currentBorrow >= 3) {  // "> 0", but also so "/ 3" makes sense
-                vm.roll(block.number + 1);
+            if (currentBorrow < 3) continue; // "> 0", but also so "/ 3" makes sense
 
-                uint256 borrowCapBelowState = currentBorrow / 3;
+            vm.roll(block.number + 1);
 
-                vm.prank(SPARK_PROXY);
-                capAutomator.setBorrowCapConfig({
-                    asset:            assets[i],
-                    max:              borrowCapBelowState,
-                    gap:              1,
-                    increaseCooldown: 12 hours
-                });
+            uint256 borrowCapBelowState = currentBorrow / 3;
 
-                vm.prank(CAP_AUTO_UPDATER);
-                capAutomator.exec(assets[i]);
+            vm.prank(SPARK_PROXY);
+            capAutomator.setBorrowCapConfig({
+                asset:            assets[i],
+                max:              borrowCapBelowState,
+                gap:              1,
+                increaseCooldown: 12 hours
+            });
 
-                postDecreaseBorrowCap = pool.getReserveData(assets[i]).configuration.getBorrowCap();
+            vm.prank(CAP_AUTO_UPDATER);
+            capAutomator.exec(assets[i]);
 
-                assertEq(postDecreaseBorrowCap, borrowCapBelowState);
-            }
+            postDecreaseBorrowCap = pool.getReserveData(assets[i]).configuration.getBorrowCap();
+
+            assertEq(postDecreaseBorrowCap, borrowCapBelowState);
         }
     }
 
-    function test_E2E_increaseSupplyCap() public {
-        for (uint256 i; i < assets.length; i++) {
+    function test_E2E_increaseSupplyCap() external {
+        for (uint256 i; i < assets.length; ++i) {
             DataTypes.ReserveData memory reserveData = pool.getReserveData(assets[i]);
 
             uint256 preIncreaseSupplyCap = reserveData.configuration.getSupplyCap();
-            uint256 currentSupply        = currentATokenSupply(reserveData);
+            uint256 currentSupply        = _currentATokenSupply(reserveData);
 
             uint256 newMaxCap;
             uint256 newGap;
@@ -243,7 +240,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 increaseCooldown: 12 hours
             });
 
-            ( 
+            (
                 ,,,
                 uint48 lastUpdateBlock,
                 uint48 lastIncreaseTime
@@ -255,7 +252,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
-            ( 
+            (
                 ,,,
                 lastUpdateBlock,
                 lastIncreaseTime
@@ -264,24 +261,23 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, block.timestamp);
 
-            uint256 postIncreaseSupplyCap 
+            uint256 postIncreaseSupplyCap
                 = pool.getReserveData(assets[i]).configuration.getSupplyCap();
 
             assertEq(postIncreaseSupplyCap, currentSupply + newGap);
         }
     }
 
-    function test_E2E_decreaseSupplyCap() public {
-        for (uint256 i; i < assets.length; i++) {
+    function test_E2E_decreaseSupplyCap() external {
+        for (uint256 i; i < assets.length; ++i) {
             DataTypes.ReserveData memory reserveData = pool.getReserveData(assets[i]);
 
             uint256 preDecreaseSupplyCap = reserveData.configuration.getSupplyCap();
-            // If there is a cap a decrease will be attempted, but if there is no cap, decrease is not possible
-            if (preDecreaseSupplyCap == 0) {
-                continue;
-            }
 
-            uint256 currentSupply        = currentATokenSupply(reserveData);
+            // If there is a cap a decrease will be attempted, but if there is no cap, decrease is not possible
+            if (preDecreaseSupplyCap == 0) continue;
+
+            uint256 currentSupply        = _currentATokenSupply(reserveData);
             uint256 preDecreaseSupplyGap = preDecreaseSupplyCap - currentSupply;
 
             uint256 newGap = preDecreaseSupplyGap / 3;
@@ -294,7 +290,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 increaseCooldown: 12 hours
             });
 
-            ( 
+            (
                 ,,,
                 uint48 lastUpdateBlock,
                 uint48 lastIncreaseTime
@@ -306,7 +302,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
-            ( 
+            (
                 ,,,
                 lastUpdateBlock,
                 lastIncreaseTime
@@ -315,31 +311,31 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, 0);
 
-            uint256 postDecreaseSupplyCap 
+            uint256 postDecreaseSupplyCap
                 = pool.getReserveData(assets[i]).configuration.getSupplyCap();
 
             assertEq(postDecreaseSupplyCap, currentSupply + newGap);
 
-            if (currentSupply >= 3) {  // "> 0", but also so "/ 3" makes sense
-                vm.roll(block.number + 1);
+            if (currentSupply < 3) continue; // "> 0", but also so "/ 3" makes sense
 
-                uint256 supplyCapBelowState = currentSupply / 3;
+            vm.roll(block.number + 1);
 
-                vm.prank(SPARK_PROXY);
-                capAutomator.setSupplyCapConfig({
-                    asset:            assets[i],
-                    max:              supplyCapBelowState,
-                    gap:              1,
-                    increaseCooldown: 12 hours
-                });
+            uint256 supplyCapBelowState = currentSupply / 3;
 
-                vm.prank(CAP_AUTO_UPDATER);
-                capAutomator.exec(assets[i]);
+            vm.prank(SPARK_PROXY);
+            capAutomator.setSupplyCapConfig({
+                asset:            assets[i],
+                max:              supplyCapBelowState,
+                gap:              1,
+                increaseCooldown: 12 hours
+            });
 
-                postDecreaseSupplyCap = pool.getReserveData(assets[i]).configuration.getSupplyCap();
+            vm.prank(CAP_AUTO_UPDATER);
+            capAutomator.exec(assets[i]);
 
-                assertEq(postDecreaseSupplyCap, supplyCapBelowState);
-            }
+            postDecreaseSupplyCap = pool.getReserveData(assets[i]).configuration.getSupplyCap();
+
+            assertEq(postDecreaseSupplyCap, supplyCapBelowState);
         }
     }
 
@@ -350,10 +346,10 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
     using ReserveConfiguration for DataTypes.ReserveConfigurationMap;
     using WadRayMath           for uint256;
 
-    uint256 USERS_STASH = 6_000e8;
+    uint256 internal constant USERS_STASH = 6_000e8;
 
-    function test_E2E_supply_wbtc() public {
-        assertEq(IERC20Metadata(WBTC).decimals(), 8);
+    function test_E2E_supply_wbtc() external {
+        assertEq(IERC20Like(WBTC).decimals(), 8);
 
         DataTypes.ReserveData memory wbtcReserveData = pool.getReserveData(WBTC);
 
@@ -361,7 +357,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         assertEq(wbtcReserveData.configuration.getSupplyCap(), 3_000);
 
         // Confirm initial WBTC supply
-        uint256 initialSupply = currentATokenSupply(wbtcReserveData);
+        uint256 initialSupply = _currentATokenSupply(wbtcReserveData);
 
         assertEq(initialSupply, 750);
 
@@ -376,7 +372,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         vm.startPrank(user);
 
         deal(WBTC, user, USERS_STASH);
-        IERC20(WBTC).approve(POOL, USERS_STASH);
+        IERC20Like(WBTC).approve(POOL, USERS_STASH);
 
         pool.supply(WBTC, 2_000e8, user, 0);
 
@@ -452,16 +448,16 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         capAutomator.execSupply(WBTC);
 
         // initialSupply + suppliedInTest - withdrawnInTest = 750 + 2_000 + 250 - 125 - 125 = 750 + 2_250 - 250 = 2_750
-        assertEq(currentATokenSupply(pool.getReserveData(WBTC)),         2_750);
+        assertEq(_currentATokenSupply(pool.getReserveData(WBTC)),        2_750);
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 1_000);
 
-        vm.prank(user);
         vm.expectRevert(bytes("51"));  // SUPPLY_CAP_EXCEEDED
+        vm.prank(user);
         pool.supply(WBTC, 1, user, 0);
     }
 
-    function test_E2E_borrow_weth() public {
-        assertEq(IERC20Metadata(WETH).decimals(), 18);
+    function test_E2E_borrow_weth() external {
+        assertEq(IERC20Like(WETH).decimals(), 18);
 
         DataTypes.ReserveData memory wethReserveData = pool.getReserveData(WETH);
 
@@ -486,7 +482,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         vm.startPrank(user);
 
         deal(WBTC, user, USERS_STASH);
-        IERC20(WBTC).approve(POOL, USERS_STASH);
+        IERC20Like(WBTC).approve(POOL, USERS_STASH);
 
         pool.supply(WBTC, 2_000e8, user, 0);
 
@@ -517,7 +513,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 227_000);
 
         vm.startPrank(user);
-        IERC20(WETH).approve(POOL, 50e18);
+        IERC20Like(WETH).approve(POOL, 50e18);
         pool.repay(WETH, 50e18, 2 /* variable rate mode */, user);
         vm.stopPrank();
 
@@ -567,17 +563,17 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // = 126_520 + 480 + 150 - 50 + 10 = 227_000
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 100_000);
 
-        vm.prank(user);
         vm.expectRevert(bytes("50"));  // BORROW_CAP_EXCEEDED
+        vm.prank(user);
         pool.borrow(WETH, 1, 2 /* variable rate mode */, 0, user);
     }
 
-    function test_E2E_flashloan() public {
+    function test_E2E_flashloan() external {
         DataTypes.ReserveData memory initialReserveData = pool.getReserveData(WBTC);
 
         // Confirm initial state
-        assertEq(IERC20Metadata(WBTC).decimals(),                 8);
-        assertEq(currentATokenSupply(initialReserveData),         750);
+        assertEq(IERC20Like(WBTC).decimals(),                 8);
+        assertEq(_currentATokenSupply(initialReserveData),         750);
         assertEq(initialReserveData.configuration.getSupplyCap(), 3_000);
 
         vm.prank(SPARK_PROXY);
@@ -590,6 +586,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         vm.roll(block.number + 1);
         skip(12 hours + 1);
 
@@ -607,7 +604,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Confirm the cap increase even though the supply effectively didn't change
         DataTypes.ReserveData memory postFlashloanReserveData = pool.getReserveData(WBTC);
 
-        assertEq(currentATokenSupply(postFlashloanReserveData),         750);
+        assertEq(_currentATokenSupply(postFlashloanReserveData),         750);
         assertEq(postFlashloanReserveData.configuration.getSupplyCap(), 850);
 
         // Confirm that in the next block, before increase cooldown passes, cap can be decreased
@@ -621,7 +618,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         skip(6 hours);
 
         deal(WBTC, address(this), 40e8);
-        IERC20(WBTC).approve(address(pool), 40e8);
+        IERC20Like(WBTC).approve(address(pool), 40e8);
         pool.supply(WBTC, 40e8, address(this), 0);
 
         // Confirm that after some time, smaller than cooldown, cap cannot be increased
@@ -641,29 +638,30 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
     // Called back from the flashloan
     function executeOperation(
-        address asset,
-        uint256 amount,
+        address          asset,
+        uint256          amount,
         uint256,
         address,
-        bytes calldata
+        bytes   calldata
     ) external returns (bool) {
         DataTypes.ReserveData memory initialReserveData = pool.getReserveData(WBTC);
 
-        uint256 currentExactSupply 
-            = (
-                IScaledBalanceToken(initialReserveData.aTokenAddress).scaledTotalSupply() 
-                + uint256(initialReserveData.accruedToTreasury)
+        uint256 currentExactSupply =
+            (
+                IScaledBalanceTokenLike(initialReserveData.aTokenAddress).scaledTotalSupply()
+                + initialReserveData.accruedToTreasury
             ).rayMul(initialReserveData.liquidityIndex);
+
         uint256 dust = currentExactSupply % 1e8;
 
         // Confirm that at the beginning the max possible supply is the gap value minus the dust
         assertEq(
-            initialReserveData.configuration.getSupplyCap() * 1e8 - currentExactSupply, 
+            initialReserveData.configuration.getSupplyCap() * 1e8 - currentExactSupply,
             50e8 - dust
         );
 
         // Supply additional funds to the pool, bring the supply closer to the cap than the gap
-        IERC20(asset).approve(address(pool), 50e8 - dust);
+        IERC20Like(asset).approve(address(pool), 50e8 - dust);
         pool.supply(WBTC, 50e8 - dust, address(this), 0);
 
         // Confirm previous cap before the update
@@ -678,7 +676,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 850);
 
         // Supply more funds to attempt a second cap increase
-        IERC20(asset).approve(address(pool), 50e8);
+        IERC20Like(asset).approve(address(pool), 50e8);
         pool.supply(WBTC, 50e8, address(this), 0);
 
         // Confirm the cap cannot be increased twice
@@ -698,7 +696,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 850);
 
-        IERC20(asset).approve(address(pool), amount);
+        IERC20Like(asset).approve(address(pool), amount);
 
         return true;
     }

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -13,6 +13,8 @@ import { IACLManager }          from "aave-v3-core-contracts/interfaces/IACLMana
 import { IPool }                from "aave-v3-core-contracts/interfaces/IPool.sol";
 import { IScaledBalanceToken }  from "aave-v3-core-contracts/interfaces/IScaledBalanceToken.sol";
 
+import { Ethereum } from "spark-address-registry/Ethereum.sol";
+
 import { CapAutomator } from "../src/CapAutomator.sol";
 
 contract CapAutomatorIntegrationTestsBase is Test {
@@ -24,10 +26,10 @@ contract CapAutomatorIntegrationTestsBase is Test {
     address public constant POOL_CONFIG             = 0x542DBa469bdE58FAeE189ffB60C6b49CE60E0738;
     address public constant DATA_PROVIDER           = 0xFc21d6d146E6086B8359705C8b28512a983db0cb;
     address public constant ACL_MANAGER             = 0xdA135Cd78A086025BcdC87B038a1C462032b510C;
-    address public constant SPARK_PROXY             = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;
+    address public constant SPARK_PROXY             = Ethereum.SPARK_PROXY;
     address public constant CAP_AUTO_UPDATER        = address(0xdead); // @todo : FIX ME
-    address public constant WETH                    = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
-    address public constant WBTC                    = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+    address public constant WETH                    = Ethereum.WETH;
+    address public constant WBTC                    = Ethereum.WBTC;
 
     address public user;
 
@@ -42,7 +44,7 @@ contract CapAutomatorIntegrationTestsBase is Test {
         vm.createSelectFork(getChain("mainnet").rpcUrl, 18721430);
 
         vm.prank(SPARK_PROXY);
-        capAutomator = new CapAutomator(POOL_ADDRESSES_PROVIDER, CAP_AUTO_UPDATER);
+        capAutomator = new CapAutomator(POOL_ADDRESSES_PROVIDER, SPARK_PROXY, CAP_AUTO_UPDATER);
 
         vm.prank(SPARK_PROXY);
         aclManager.addRiskAdmin(address(capAutomator));
@@ -52,12 +54,19 @@ contract CapAutomatorIntegrationTestsBase is Test {
         user = makeAddr("user");
     }
 
-    function currentATokenSupply(DataTypes.ReserveData memory _reserveData) internal view returns (uint256) {
-        return (IScaledBalanceToken(_reserveData.aTokenAddress).scaledTotalSupply() + uint256(_reserveData.accruedToTreasury)).rayMul(_reserveData.liquidityIndex)
-            / 10 ** IERC20Metadata(_reserveData.aTokenAddress).decimals();
+    function currentATokenSupply(
+        DataTypes.ReserveData memory _reserveData
+    ) internal view returns (uint256) {
+        return (
+            IScaledBalanceToken(_reserveData.aTokenAddress).scaledTotalSupply()
+            + uint256(_reserveData.accruedToTreasury)
+        ).rayMul(_reserveData.liquidityIndex)
+        / 10 ** IERC20Metadata(_reserveData.aTokenAddress).decimals();
     }
 
-    function currentBorrows(DataTypes.ReserveData memory _reserveData) internal view returns (uint256) {
+    function currentBorrows(
+        DataTypes.ReserveData memory _reserveData
+    ) internal view returns (uint256) {
         return IERC20(_reserveData.variableDebtTokenAddress).totalSupply()
             / 10 ** IERC20Metadata(_reserveData.variableDebtTokenAddress).decimals();
     }
@@ -101,18 +110,27 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 increaseCooldown: 12 hours
             });
 
-            ( ,,, uint48 lastUpdateBlock, uint48 lastIncreaseTime ) = capAutomator.borrowCapConfigs(assets[i]);
+            ( 
+                ,,,
+                uint48 lastUpdateBlock,
+                uint48 lastIncreaseTime
+            ) = capAutomator.borrowCapConfigs(assets[i]);
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
             vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
-            ( ,,, lastUpdateBlock, lastIncreaseTime ) = capAutomator.borrowCapConfigs(assets[i]);
+            ( 
+                ,,,
+                lastUpdateBlock,
+                lastIncreaseTime
+            ) = capAutomator.borrowCapConfigs(assets[i]);
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, block.timestamp);
 
-            uint256 postIncreaseBorrowCap = pool.getReserveData(assets[i]).configuration.getBorrowCap();
+            uint256 postIncreaseBorrowCap 
+                = pool.getReserveData(assets[i]).configuration.getBorrowCap();
             assertEq(postIncreaseBorrowCap, currentBorrow + newGap);
         }
     }
@@ -140,18 +158,27 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 increaseCooldown: 12 hours
             });
 
-            ( ,,, uint48 lastUpdateBlock, uint48 lastIncreaseTime ) = capAutomator.borrowCapConfigs(assets[i]);
+            ( 
+                ,,,
+                uint48 lastUpdateBlock,
+                uint48 lastIncreaseTime
+            ) = capAutomator.borrowCapConfigs(assets[i]);
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
             vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
-            ( ,,, lastUpdateBlock, lastIncreaseTime ) = capAutomator.borrowCapConfigs(assets[i]);
+            ( 
+                ,,,
+                lastUpdateBlock,
+                lastIncreaseTime
+            ) = capAutomator.borrowCapConfigs(assets[i]);
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, 0);
 
-            uint256 postDecreaseBorrowCap = pool.getReserveData(assets[i]).configuration.getBorrowCap();
+            uint256 postDecreaseBorrowCap 
+                = pool.getReserveData(assets[i]).configuration.getBorrowCap();
             assertEq(postDecreaseBorrowCap, currentBorrow + newGap);
 
             if (currentBorrow >= 3) {  // "> 0", but also so "/ 3" makes sense
@@ -208,18 +235,27 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 increaseCooldown: 12 hours
             });
 
-            ( ,,, uint48 lastUpdateBlock, uint48 lastIncreaseTime ) = capAutomator.supplyCapConfigs(assets[i]);
+            ( 
+                ,,,
+                uint48 lastUpdateBlock,
+                uint48 lastIncreaseTime
+            ) = capAutomator.supplyCapConfigs(assets[i]);
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
             vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
-            ( ,,, lastUpdateBlock, lastIncreaseTime ) = capAutomator.supplyCapConfigs(assets[i]);
+            ( 
+                ,,,
+                lastUpdateBlock,
+                lastIncreaseTime
+            ) = capAutomator.supplyCapConfigs(assets[i]);
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, block.timestamp);
 
-            uint256 postIncreaseSupplyCap = pool.getReserveData(assets[i]).configuration.getSupplyCap();
+            uint256 postIncreaseSupplyCap 
+                = pool.getReserveData(assets[i]).configuration.getSupplyCap();
             assertEq(postIncreaseSupplyCap, currentSupply + newGap);
         }
     }
@@ -247,18 +283,27 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 increaseCooldown: 12 hours
             });
 
-            ( ,,, uint48 lastUpdateBlock, uint48 lastIncreaseTime ) = capAutomator.supplyCapConfigs(assets[i]);
+            ( 
+                ,,,
+                uint48 lastUpdateBlock,
+                uint48 lastIncreaseTime
+            ) = capAutomator.supplyCapConfigs(assets[i]);
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
             vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
-            ( ,,, lastUpdateBlock, lastIncreaseTime ) = capAutomator.supplyCapConfigs(assets[i]);
+            ( 
+                ,,,
+                lastUpdateBlock,
+                lastIncreaseTime
+            ) = capAutomator.supplyCapConfigs(assets[i]);
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, 0);
 
-            uint256 postDecreaseSupplyCap = pool.getReserveData(assets[i]).configuration.getSupplyCap();
+            uint256 postDecreaseSupplyCap 
+                = pool.getReserveData(assets[i]).configuration.getSupplyCap();
             assertEq(postDecreaseSupplyCap, currentSupply + newGap);
 
             if (currentSupply >= 3) {  // "> 0", but also so "/ 3" makes sense
@@ -572,12 +617,18 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
     ) external returns (bool) {
         DataTypes.ReserveData memory initialReserveData = pool.getReserveData(WBTC);
 
-        uint256 currentExactSupply = (IScaledBalanceToken(initialReserveData.aTokenAddress).scaledTotalSupply() + uint256(initialReserveData.accruedToTreasury))
-            .rayMul(initialReserveData.liquidityIndex);
+        uint256 currentExactSupply 
+            = (
+                IScaledBalanceToken(initialReserveData.aTokenAddress).scaledTotalSupply() 
+                + uint256(initialReserveData.accruedToTreasury)
+            ).rayMul(initialReserveData.liquidityIndex);
         uint256 dust = currentExactSupply % 1e8;
 
         // Confirm that at the beginning the max possible supply is the gap value minus the dust
-        assertEq(initialReserveData.configuration.getSupplyCap() * 1e8 - currentExactSupply, 50e8 - dust);
+        assertEq(
+            initialReserveData.configuration.getSupplyCap() * 1e8 - currentExactSupply, 
+            50e8 - dust
+        );
 
         // Supply additional funds to the pool, bring the supply closer to the cap than the gap
         IERC20(asset).approve(address(pool), 50e8 - dust);

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -6,12 +6,12 @@ import "forge-std/Test.sol";
 import { IERC20 }         from "openzeppelin-contracts/interfaces/IERC20.sol";
 import { IERC20Metadata } from "openzeppelin-contracts/interfaces/IERC20Metadata.sol";
 
-import { ReserveConfiguration } from "aave-v3-core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
-import { DataTypes }            from "aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
-import { WadRayMath }           from "aave-v3-core/contracts/protocol/libraries/math/WadRayMath.sol";
-import { IACLManager }          from "aave-v3-core/contracts/interfaces/IACLManager.sol";
-import { IPool }                from "aave-v3-core/contracts/interfaces/IPool.sol";
-import { IScaledBalanceToken }  from "aave-v3-core/contracts/interfaces/IScaledBalanceToken.sol";
+import { ReserveConfiguration } from "aave-v3-core-contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
+import { DataTypes }            from "aave-v3-core-contracts/protocol/libraries/types/DataTypes.sol";
+import { WadRayMath }           from "aave-v3-core-contracts/protocol/libraries/math/WadRayMath.sol";
+import { IACLManager }          from "aave-v3-core-contracts/interfaces/IACLManager.sol";
+import { IPool }                from "aave-v3-core-contracts/interfaces/IPool.sol";
+import { IScaledBalanceToken }  from "aave-v3-core-contracts/interfaces/IScaledBalanceToken.sol";
 
 import { CapAutomator } from "../src/CapAutomator.sol";
 
@@ -25,6 +25,7 @@ contract CapAutomatorIntegrationTestsBase is Test {
     address public constant DATA_PROVIDER           = 0xFc21d6d146E6086B8359705C8b28512a983db0cb;
     address public constant ACL_MANAGER             = 0xdA135Cd78A086025BcdC87B038a1C462032b510C;
     address public constant SPARK_PROXY             = 0x3300f198988e4C9C63F75dF86De36421f06af8c4;
+    address public constant CAP_AUTO_UPDATER        = address(0xdead); // @todo : FIX ME
     address public constant WETH                    = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address public constant WBTC                    = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
 
@@ -40,9 +41,8 @@ contract CapAutomatorIntegrationTestsBase is Test {
     function setUp() public {
         vm.createSelectFork(getChain("mainnet").rpcUrl, 18721430);
 
-        capAutomator = new CapAutomator(POOL_ADDRESSES_PROVIDER);
-
-        capAutomator.transferOwnership(SPARK_PROXY);
+        vm.prank(SPARK_PROXY);
+        capAutomator = new CapAutomator(POOL_ADDRESSES_PROVIDER, CAP_AUTO_UPDATER);
 
         vm.prank(SPARK_PROXY);
         aclManager.addRiskAdmin(address(capAutomator));
@@ -105,6 +105,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
+            vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
             ( ,,, lastUpdateBlock, lastIncreaseTime ) = capAutomator.borrowCapConfigs(assets[i]);
@@ -143,6 +144,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
+            vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
             ( ,,, lastUpdateBlock, lastIncreaseTime ) = capAutomator.borrowCapConfigs(assets[i]);
@@ -165,6 +167,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                     increaseCooldown: 12 hours
                 });
 
+                vm.prank(CAP_AUTO_UPDATER);
                 capAutomator.exec(assets[i]);
 
                 postDecreaseBorrowCap = pool.getReserveData(assets[i]).configuration.getBorrowCap();
@@ -209,6 +212,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
+            vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
             ( ,,, lastUpdateBlock, lastIncreaseTime ) = capAutomator.supplyCapConfigs(assets[i]);
@@ -247,6 +251,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
+            vm.prank(CAP_AUTO_UPDATER);
             capAutomator.exec(assets[i]);
 
             ( ,,, lastUpdateBlock, lastIncreaseTime ) = capAutomator.supplyCapConfigs(assets[i]);
@@ -269,6 +274,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                     increaseCooldown: 12 hours
                 });
 
+                vm.prank(CAP_AUTO_UPDATER);
                 capAutomator.exec(assets[i]);
 
                 postDecreaseSupplyCap = pool.getReserveData(assets[i]).configuration.getSupplyCap();
@@ -318,6 +324,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Confirm that WBTC supply cap didn't change yet
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_000);
 
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
 
         // Confirm correct WBTC supply cap increase
@@ -329,11 +336,13 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         pool.supply(WBTC, 250e8, user, 0);
 
         // Check the cap is not changing before cooldown passes
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_250);
 
         // Check correct cap increase after cooldown
         skip(24 hours);
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         // initialSupply + suppliedBefore + newlySupplied + gap = 750 + 2_000 + 250 + 500 = 3_500
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_500);
@@ -343,6 +352,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         pool.withdraw(WBTC, 125e8, user);
 
         // Check correct cap decrease (without cooldown)
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         // previousSupply - justWithdrawn + gap = 3_000 - 125 + 500 = 3_375
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_375);
@@ -351,11 +361,13 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         pool.withdraw(WBTC, 125e8, user);
 
         // Check the cap is not changing in the same block
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_375);
 
         // Check correct cap decrease after block changes
         vm.roll(block.number + 1);
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         // previousSupply - justWithdrawn + gap = 2_875 - 125 + 500 = 3_250
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_250);
@@ -370,6 +382,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         });
 
         vm.roll(block.number + 1);
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
 
         assertEq(currentATokenSupply(pool.getReserveData(WBTC)), 2_750);
@@ -413,6 +426,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         vm.stopPrank();
 
         // Check correct cap decrease
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
         // totalDebt + gap = 126_520 + 100_000 = 226_520
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 226_520);
@@ -421,11 +435,13 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         pool.borrow(WETH, 480e18, 2 /* variable rate mode */, 0, user);
 
         // Check that another cap change is not possible in the same block
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 226_520);
 
         // Check correct cap increase in the new block
         vm.roll(block.number + 1);
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
         // totalDebt + gap = initialBorrows + newlyBorrowed + gap = 126_520 + 480 + 100_000 = 227_000
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 227_000);
@@ -437,6 +453,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         // Check correct cap decrease without cooldown passing
         vm.roll(block.number + 1);
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
         // totalDebt + gap = initialBorrows + previouslyBorrowed - newlyRepaid + gap = 126_520 + 480 - 50 + 100_000 = 226_950
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 226_950);
@@ -446,11 +463,13 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         vm.roll(block.number + 1);
         // Check the cap is not increasing before cooldown passes
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 226_950);
 
         // Check correct cap increase after cooldown
         skip(24 hours);
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
         // totalDebt + gap = initialBorrows + previouslyBorrowed - previouslyRepaid + justBorrowed + debtAccruedIn24h + gap
         // = 126_520 + 480 - 50 + 150 + 10 + 100_000 = 227_000
@@ -466,6 +485,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         });
 
         vm.roll(block.number + 1);
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
 
         assertEq(currentBorrows(pool.getReserveData(WETH)), 127_110);
@@ -495,6 +515,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
             increaseCooldown: 12 hours
         });
 
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         vm.roll(block.number + 1);
         skip(12 hours + 1);
@@ -517,6 +538,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         // Confirm that in the next block, before increase cooldown passes, cap can be decreased
         vm.roll(block.number + 1);
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 800);
 
@@ -528,12 +550,14 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         pool.supply(WBTC, 40e8, address(this), 0);
 
         // Confirm that after some time, smaller than cooldown, cap cannot be increased
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 800);
 
         skip(6 hours + 1);
 
         // Confirm that after sufficient time passes, cap can be increased again
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 840);
     }
@@ -565,6 +589,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         // Confirm the cap can be correctly increased
         // initialSupply + maxPossibleSupplyBeforeCapIncrease + gap = (750 + dust) + (50 - dust) + 50 = 850
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 850);
 
@@ -574,6 +599,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         // Confirm the cap cannot be increased twice
         // initialSupply + totalSuppliedFunds + gap = (750 + dust) + (100 - dust) + 50 = 900
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 850);
 
@@ -582,6 +608,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         // Confirm the cap cannot be decreased in the same block, even though the supply came back to the initial state
         // initialSupply + totalSuppliedFunds - withdrawnFunds + gap = (750 + dust) + (100 - dust) - (100 - dust) + 50 = 800
+        vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 850);
 

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -572,8 +572,8 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         DataTypes.ReserveData memory initialReserveData = pool.getReserveData(WBTC);
 
         // Confirm initial state
-        assertEq(IERC20Like(WBTC).decimals(),                 8);
-        assertEq(_currentATokenSupply(initialReserveData),         750);
+        assertEq(IERC20Like(WBTC).decimals(),                     8);
+        assertEq(_currentATokenSupply(initialReserveData),        750);
         assertEq(initialReserveData.configuration.getSupplyCap(), 3_000);
 
         vm.prank(SPARK_PROXY);
@@ -604,7 +604,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Confirm the cap increase even though the supply effectively didn't change
         DataTypes.ReserveData memory postFlashloanReserveData = pool.getReserveData(WBTC);
 
-        assertEq(_currentATokenSupply(postFlashloanReserveData),         750);
+        assertEq(_currentATokenSupply(postFlashloanReserveData),        750);
         assertEq(postFlashloanReserveData.configuration.getSupplyCap(), 850);
 
         // Confirm that in the next block, before increase cooldown passes, cap can be decreased

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -28,7 +28,7 @@ contract CapAutomatorIntegrationTestsBase is Test {
     address public constant DATA_PROVIDER           = SparkLend.PROTOCOL_DATA_PROVIDER;
     address public constant ACL_MANAGER             = SparkLend.ACL_MANAGER;
     address public constant SPARK_PROXY             = Ethereum.SPARK_PROXY;
-    address public constant CAP_AUTO_UPDATER        = SparkLend.CAP_AUTOMATOR;
+    address public constant CAP_AUTO_UPDATER        = Ethereum.ALM_RELAYER_MULTISIG;
     address public constant WETH                    = Ethereum.WETH;
     address public constant WBTC                    = Ethereum.WBTC;
 
@@ -116,6 +116,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 uint48 lastUpdateBlock,
                 uint48 lastIncreaseTime
             ) = capAutomator.borrowCapConfigs(assets[i]);
+
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
@@ -127,11 +128,13 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 lastUpdateBlock,
                 lastIncreaseTime
             ) = capAutomator.borrowCapConfigs(assets[i]);
+
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, block.timestamp);
 
             uint256 postIncreaseBorrowCap 
                 = pool.getReserveData(assets[i]).configuration.getBorrowCap();
+
             assertEq(postIncreaseBorrowCap, currentBorrow + newGap);
         }
     }
@@ -164,6 +167,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 uint48 lastUpdateBlock,
                 uint48 lastIncreaseTime
             ) = capAutomator.borrowCapConfigs(assets[i]);
+
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
@@ -175,11 +179,13 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 lastUpdateBlock,
                 lastIncreaseTime
             ) = capAutomator.borrowCapConfigs(assets[i]);
+
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, 0);
 
             uint256 postDecreaseBorrowCap 
                 = pool.getReserveData(assets[i]).configuration.getBorrowCap();
+
             assertEq(postDecreaseBorrowCap, currentBorrow + newGap);
 
             if (currentBorrow >= 3) {  // "> 0", but also so "/ 3" makes sense
@@ -199,6 +205,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 capAutomator.exec(assets[i]);
 
                 postDecreaseBorrowCap = pool.getReserveData(assets[i]).configuration.getBorrowCap();
+
                 assertEq(postDecreaseBorrowCap, borrowCapBelowState);
             }
         }
@@ -241,6 +248,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 uint48 lastUpdateBlock,
                 uint48 lastIncreaseTime
             ) = capAutomator.supplyCapConfigs(assets[i]);
+
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
@@ -252,11 +260,13 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 lastUpdateBlock,
                 lastIncreaseTime
             ) = capAutomator.supplyCapConfigs(assets[i]);
+
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, block.timestamp);
 
             uint256 postIncreaseSupplyCap 
                 = pool.getReserveData(assets[i]).configuration.getSupplyCap();
+
             assertEq(postIncreaseSupplyCap, currentSupply + newGap);
         }
     }
@@ -289,6 +299,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 uint48 lastUpdateBlock,
                 uint48 lastIncreaseTime
             ) = capAutomator.supplyCapConfigs(assets[i]);
+
             assertEq(lastUpdateBlock,  0);
             assertEq(lastIncreaseTime, 0);
 
@@ -300,11 +311,13 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 lastUpdateBlock,
                 lastIncreaseTime
             ) = capAutomator.supplyCapConfigs(assets[i]);
+
             assertEq(lastUpdateBlock,  block.number);
             assertEq(lastIncreaseTime, 0);
 
             uint256 postDecreaseSupplyCap 
                 = pool.getReserveData(assets[i]).configuration.getSupplyCap();
+
             assertEq(postDecreaseSupplyCap, currentSupply + newGap);
 
             if (currentSupply >= 3) {  // "> 0", but also so "/ 3" makes sense
@@ -324,6 +337,7 @@ contract GeneralizedTests is CapAutomatorIntegrationTestsBase {
                 capAutomator.exec(assets[i]);
 
                 postDecreaseSupplyCap = pool.getReserveData(assets[i]).configuration.getSupplyCap();
+
                 assertEq(postDecreaseSupplyCap, supplyCapBelowState);
             }
         }
@@ -348,6 +362,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         // Confirm initial WBTC supply
         uint256 initialSupply = currentATokenSupply(wbtcReserveData);
+
         assertEq(initialSupply, 750);
 
         vm.prank(SPARK_PROXY);
@@ -384,12 +399,14 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Check the cap is not changing before cooldown passes
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_250);
 
         // Check correct cap increase after cooldown
         skip(24 hours);
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         // initialSupply + suppliedBefore + newlySupplied + gap = 750 + 2_000 + 250 + 500 = 3_500
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_500);
 
@@ -400,6 +417,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Check correct cap decrease (without cooldown)
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         // previousSupply - justWithdrawn + gap = 3_000 - 125 + 500 = 3_375
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_375);
 
@@ -409,12 +427,14 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Check the cap is not changing in the same block
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_375);
 
         // Check correct cap decrease after block changes
         vm.roll(block.number + 1);
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         // previousSupply - justWithdrawn + gap = 2_875 - 125 + 500 = 3_250
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 3_250);
 
@@ -431,14 +451,13 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
 
-        assertEq(currentATokenSupply(pool.getReserveData(WBTC)), 2_750);
         // initialSupply + suppliedInTest - withdrawnInTest = 750 + 2_000 + 250 - 125 - 125 = 750 + 2_250 - 250 = 2_750
+        assertEq(currentATokenSupply(pool.getReserveData(WBTC)),         2_750);
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 1_000);
 
-        vm.startPrank(user);
+        vm.prank(user);
         vm.expectRevert(bytes("51"));  // SUPPLY_CAP_EXCEEDED
         pool.supply(WBTC, 1, user, 0);
-        vm.stopPrank();
     }
 
     function test_E2E_borrow_weth() public {
@@ -448,10 +467,12 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         // Confirm initial borrow cap
         uint256 initialBorrowCap = wethReserveData.configuration.getBorrowCap();
+
         assertEq(initialBorrowCap, 1_400_000);
 
         // Confirm initial borrows
         uint256 initialBorrows = currentBorrows(wethReserveData);
+
         assertEq(initialBorrows, 126_520);
 
         vm.prank(SPARK_PROXY);
@@ -474,6 +495,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Check correct cap decrease
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
+
         // totalDebt + gap = 126_520 + 100_000 = 226_520
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 226_520);
 
@@ -483,12 +505,14 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Check that another cap change is not possible in the same block
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
+
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 226_520);
 
         // Check correct cap increase in the new block
         vm.roll(block.number + 1);
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
+
         // totalDebt + gap = initialBorrows + newlyBorrowed + gap = 126_520 + 480 + 100_000 = 227_000
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 227_000);
 
@@ -501,6 +525,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         vm.roll(block.number + 1);
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
+
         // totalDebt + gap = initialBorrows + previouslyBorrowed - newlyRepaid + gap = 126_520 + 480 - 50 + 100_000 = 226_950
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 226_950);
 
@@ -511,12 +536,14 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Check the cap is not increasing before cooldown passes
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
+
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 226_950);
 
         // Check correct cap increase after cooldown
         skip(24 hours);
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execBorrow(WETH);
+
         // totalDebt + gap = initialBorrows + previouslyBorrowed - previouslyRepaid + justBorrowed + debtAccruedIn24h + gap
         // = 126_520 + 480 - 50 + 150 + 10 + 100_000 = 227_000
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 227_110);
@@ -535,14 +562,14 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         capAutomator.execBorrow(WETH);
 
         assertEq(currentBorrows(pool.getReserveData(WETH)), 127_110);
+
         // initialBorrows + borrowedInTest - repaidInTest + debtAccruedIn24h
         // = 126_520 + 480 + 150 - 50 + 10 = 227_000
         assertEq(pool.getReserveData(WETH).configuration.getBorrowCap(), 100_000);
 
-        vm.startPrank(user);
+        vm.prank(user);
         vm.expectRevert(bytes("50"));  // BORROW_CAP_EXCEEDED
         pool.borrow(WETH, 1, 2 /* variable rate mode */, 0, user);
-        vm.stopPrank();
     }
 
     function test_E2E_flashloan() public {
@@ -579,6 +606,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
 
         // Confirm the cap increase even though the supply effectively didn't change
         DataTypes.ReserveData memory postFlashloanReserveData = pool.getReserveData(WBTC);
+
         assertEq(currentATokenSupply(postFlashloanReserveData),         750);
         assertEq(postFlashloanReserveData.configuration.getSupplyCap(), 850);
 
@@ -586,6 +614,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         vm.roll(block.number + 1);
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 800);
 
         vm.roll(block.number + 1);
@@ -598,6 +627,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Confirm that after some time, smaller than cooldown, cap cannot be increased
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 800);
 
         skip(6 hours + 1);
@@ -605,6 +635,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // Confirm that after sufficient time passes, cap can be increased again
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 840);
     }
 
@@ -643,6 +674,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // initialSupply + maxPossibleSupplyBeforeCapIncrease + gap = (750 + dust) + (50 - dust) + 50 = 850
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 850);
 
         // Supply more funds to attempt a second cap increase
@@ -653,6 +685,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // initialSupply + totalSuppliedFunds + gap = (750 + dust) + (100 - dust) + 50 = 900
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 850);
 
         // Withdraw funds to pay back the flashloan
@@ -662,6 +695,7 @@ contract ConcreteTests is CapAutomatorIntegrationTestsBase {
         // initialSupply + totalSuppliedFunds - withdrawnFunds + gap = (750 + dust) + (100 - dust) - (100 - dust) + 50 = 800
         vm.prank(CAP_AUTO_UPDATER);
         capAutomator.execSupply(WBTC);
+
         assertEq(pool.getReserveData(WBTC).configuration.getSupplyCap(), 850);
 
         IERC20(asset).approve(address(pool), amount);

--- a/test/Integration.t.sol
+++ b/test/Integration.t.sol
@@ -13,7 +13,8 @@ import { IACLManager }          from "aave-v3-core-contracts/interfaces/IACLMana
 import { IPool }                from "aave-v3-core-contracts/interfaces/IPool.sol";
 import { IScaledBalanceToken }  from "aave-v3-core-contracts/interfaces/IScaledBalanceToken.sol";
 
-import { Ethereum } from "spark-address-registry/Ethereum.sol";
+import { Ethereum }  from "spark-address-registry/Ethereum.sol";
+import { SparkLend } from "spark-address-registry/SparkLend.sol";
 
 import { CapAutomator } from "../src/CapAutomator.sol";
 
@@ -21,13 +22,13 @@ contract CapAutomatorIntegrationTestsBase is Test {
 
     using WadRayMath for uint256;
 
-    address public constant POOL_ADDRESSES_PROVIDER = 0x02C3eA4e34C0cBd694D2adFa2c690EECbC1793eE;
-    address public constant POOL                    = 0xC13e21B648A5Ee794902342038FF3aDAB66BE987;
-    address public constant POOL_CONFIG             = 0x542DBa469bdE58FAeE189ffB60C6b49CE60E0738;
-    address public constant DATA_PROVIDER           = 0xFc21d6d146E6086B8359705C8b28512a983db0cb;
-    address public constant ACL_MANAGER             = 0xdA135Cd78A086025BcdC87B038a1C462032b510C;
+    address public constant POOL_ADDRESSES_PROVIDER = SparkLend.POOL_ADDRESSES_PROVIDER;
+    address public constant POOL                    = SparkLend.POOL;
+    address public constant POOL_CONFIG             = SparkLend.POOL_CONFIGURATOR;
+    address public constant DATA_PROVIDER           = SparkLend.PROTOCOL_DATA_PROVIDER;
+    address public constant ACL_MANAGER             = SparkLend.ACL_MANAGER;
     address public constant SPARK_PROXY             = Ethereum.SPARK_PROXY;
-    address public constant CAP_AUTO_UPDATER        = address(0xdead); // @todo : FIX ME
+    address public constant CAP_AUTO_UPDATER        = SparkLend.CAP_AUTOMATOR;
     address public constant WETH                    = Ethereum.WETH;
     address public constant WBTC                    = Ethereum.WBTC;
 

--- a/test/harnesses/CapAutomatorHarness.sol
+++ b/test/harnesses/CapAutomatorHarness.sol
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
-import { IPool }             from "aave-v3-core-contracts/interfaces/IPool.sol";
-import { IPoolConfigurator } from "aave-v3-core-contracts/interfaces/IPoolConfigurator.sol";
-
-import { CapAutomator } from "src/CapAutomator.sol";
+import { CapAutomator } from "../../src/CapAutomator.sol";
 
 contract CapAutomatorHarness is CapAutomator {
 
@@ -16,14 +13,10 @@ contract CapAutomatorHarness is CapAutomator {
 
     function _calculateNewCapExternal(
         CapConfig memory capConfig,
-        uint256 currentState,
-        uint256 currentCap
+        uint256          currentState,
+        uint256          currentCap
     ) public view returns (uint256) {
-        return super._calculateNewCap(
-            capConfig,
-            currentState,
-            currentCap
-        );
+        return super._calculateNewCap(capConfig, currentState, currentCap);
     }
 
 }

--- a/test/harnesses/CapAutomatorHarness.sol
+++ b/test/harnesses/CapAutomatorHarness.sol
@@ -8,7 +8,11 @@ import { CapAutomator } from "src/CapAutomator.sol";
 
 contract CapAutomatorHarness is CapAutomator {
 
-    constructor(address poolAddressesProvider, address updater) CapAutomator(poolAddressesProvider, updater) {}
+    constructor(
+        address poolAddressesProvider,
+        address admin,
+        address updater
+    ) CapAutomator(poolAddressesProvider, admin, updater) {}
 
     function _calculateNewCapExternal(
         CapConfig memory capConfig,

--- a/test/harnesses/CapAutomatorHarness.sol
+++ b/test/harnesses/CapAutomatorHarness.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import { IPool }             from "aave-v3-core/contracts/interfaces/IPool.sol";
-import { IPoolConfigurator } from "aave-v3-core/contracts/interfaces/IPoolConfigurator.sol";
+import { IPool }             from "aave-v3-core-contracts/interfaces/IPool.sol";
+import { IPoolConfigurator } from "aave-v3-core-contracts/interfaces/IPoolConfigurator.sol";
 
 import { CapAutomator } from "src/CapAutomator.sol";
 
 contract CapAutomatorHarness is CapAutomator {
 
-    constructor(address poolAddressesProvider) CapAutomator(poolAddressesProvider) {}
+    constructor(address poolAddressesProvider, address updater) CapAutomator(poolAddressesProvider, updater) {}
 
     function _calculateNewCapExternal(
         CapConfig memory capConfig,

--- a/test/interfaces/Common.sol
+++ b/test/interfaces/Common.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.22;
+
+interface IERC20Like {
+
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    function decimals() external view returns (uint8);
+
+    function totalSupply() external view returns (uint256);
+
+}

--- a/test/interfaces/IAAVEV3.sol
+++ b/test/interfaces/IAAVEV3.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.22;
+
+import { DataTypes } from "../../lib/aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
+
+interface IACLManagerLike {
+
+    function addRiskAdmin(address admin) external;
+
+}
+
+interface IPoolLike {
+
+    function borrow(address asset, uint256 amount, uint256 interestRateMode, uint16 referralCode, address onBehalfOf) external;
+
+    function flashLoanSimple(address receiver, address asset, uint256 amount, bytes calldata params, uint16 referralCode) external;
+
+    function repay(address asset, uint256 amount, uint256 interestRateMode, address onBehalfOf) external returns (uint256);
+
+    function supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
+
+    function withdraw(address asset, uint256 amount, address to) external returns (uint256);
+
+    function getBorrowCap(address asset) external view returns (uint256);
+
+    function getReservesList() external view returns (address[] memory);
+
+    function getReserveData(address asset) external view returns (DataTypes.ReserveData memory);
+
+}
+
+interface IScaledBalanceTokenLike {
+
+    function scaledTotalSupply() external view returns (uint256);
+
+}

--- a/test/mocks/MockPool.sol
+++ b/test/mocks/MockPool.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
-import { ReserveConfiguration } from "aave-v3-core-contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
-import { DataTypes }            from "aave-v3-core-contracts/protocol/libraries/types/DataTypes.sol";
+import { ReserveConfiguration } from "../../lib/aave-v3-core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
+import { DataTypes }            from "../../lib/aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
 
 import { MockToken } from "./MockToken.sol";
 
@@ -14,8 +14,8 @@ contract MockPool {
     /*** Declarations and Constructor                                                           ***/
     /**********************************************************************************************/
 
-    MockToken public aToken;
-    MockToken public debtToken;
+    address public aToken;
+    address public debtToken;
 
     uint256 public liquidityIndex;
     uint256 public accruedToTreasury;
@@ -24,8 +24,8 @@ contract MockPool {
     uint256 public borrowCap;
 
     constructor() {
-        aToken    = new MockToken();
-        debtToken = new MockToken();
+        aToken    = address(new MockToken());
+        debtToken = address(new MockToken());
     }
 
     /**********************************************************************************************/
@@ -48,9 +48,9 @@ contract MockPool {
             currentStableBorrowRate:     uint128(0),
             lastUpdateTimestamp:         uint40(0),
             id:                          uint16(0),
-            aTokenAddress:               address(aToken),
+            aTokenAddress:               aToken,
             stableDebtTokenAddress:      address(0),
-            variableDebtTokenAddress:    address(debtToken),
+            variableDebtTokenAddress:    debtToken,
             interestRateStrategyAddress: address(0),
             accruedToTreasury:           uint128(accruedToTreasury),
             unbacked:                    uint128(0),
@@ -62,28 +62,28 @@ contract MockPool {
     /*** Mock Functions                                                                         ***/
     /**********************************************************************************************/
 
-    function __setSupplyCap(uint256 _supplyCap) external {
-        supplyCap = _supplyCap;
+    function __setSupplyCap(uint256 supplyCap_) external {
+        supplyCap = supplyCap_;
     }
 
-    function __setBorrowCap(uint256 _borrowCap) external {
-        borrowCap = _borrowCap;
+    function __setBorrowCap(uint256 borrowCap_) external {
+        borrowCap = borrowCap_;
     }
 
-    function __setATokenScaledTotalSupply(uint256 _aTokenScaledTotalSupply) external {
-        aToken.__setScaledTotalSupply(_aTokenScaledTotalSupply);
+    function __setATokenScaledTotalSupply(uint256 aTokenScaledTotalSupply_) external {
+        MockToken(aToken).__setScaledTotalSupply(aTokenScaledTotalSupply_);
     }
 
-    function __setTotalDebt(uint256 _totalDebt) external {
-        debtToken.__setTotalSupply(_totalDebt);
+    function __setTotalDebt(uint256 totalDebt_) external {
+        MockToken(debtToken).__setTotalSupply(totalDebt_);
     }
 
-    function __setLiquidityIndex(uint256 _liquidityIndex) external {
-        liquidityIndex = _liquidityIndex;
+    function __setLiquidityIndex(uint256 liquidityIndex_) external {
+        liquidityIndex = liquidityIndex_;
     }
 
-    function __setAccruedToTreasury(uint256 _accruedToTreasury) external {
-        accruedToTreasury = _accruedToTreasury;
+    function __setAccruedToTreasury(uint256 accruedToTreasury_) external {
+        accruedToTreasury = accruedToTreasury_;
     }
 
 }

--- a/test/mocks/MockPool.sol
+++ b/test/mocks/MockPool.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import { ReserveConfiguration } from "aave-v3-core/contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
-import { DataTypes }            from "aave-v3-core/contracts/protocol/libraries/types/DataTypes.sol";
+import { ReserveConfiguration } from "aave-v3-core-contracts/protocol/libraries/configuration/ReserveConfiguration.sol";
+import { DataTypes }            from "aave-v3-core-contracts/protocol/libraries/types/DataTypes.sol";
 
 import { MockToken } from "./MockToken.sol";
 

--- a/test/mocks/MockPoolAddressesProvider.sol
+++ b/test/mocks/MockPoolAddressesProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 contract MockPoolAddressesProvider {
 
@@ -10,9 +10,9 @@ contract MockPoolAddressesProvider {
     address public pool;
     address public poolConfigurator;
 
-    constructor(address _pool, address _poolConfigurator) {
-        pool             = _pool;
-        poolConfigurator = _poolConfigurator;
+    constructor(address pool_, address poolConfigurator_) {
+        pool             = pool_;
+        poolConfigurator = poolConfigurator_;
     }
 
     /**********************************************************************************************/

--- a/test/mocks/MockPoolConfigurator.sol
+++ b/test/mocks/MockPoolConfigurator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import { MockPool } from "./MockPool.sol";
 
@@ -9,10 +9,10 @@ contract MockPoolConfigurator {
     /*** Declarations and Constructor                                                           ***/
     /**********************************************************************************************/
 
-    MockPool public mockPool;
+    address public mockPool;
 
-    constructor(MockPool _mockPool) {
-        mockPool = _mockPool;
+    constructor(address mockPool_) {
+        mockPool = mockPool_;
     }
 
     /**********************************************************************************************/
@@ -20,11 +20,11 @@ contract MockPoolConfigurator {
     /**********************************************************************************************/
 
     function setSupplyCap(address, uint256 supplyCap) external {
-        mockPool.__setSupplyCap(supplyCap);
+        MockPool(mockPool).__setSupplyCap(supplyCap);
     }
 
     function setBorrowCap(address, uint256 borrowCap) external {
-        mockPool.__setBorrowCap(borrowCap);
+        MockPool(mockPool).__setBorrowCap(borrowCap);
     }
 
 }

--- a/test/mocks/MockToken.sol
+++ b/test/mocks/MockToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 contract MockToken {
 
@@ -15,16 +15,16 @@ contract MockToken {
     /*** Mock Functions                                                                         ***/
     /**********************************************************************************************/
 
-    function __setTotalSupply(uint256 _totalSupply) public {
-        totalSupply = _totalSupply;
+    function __setTotalSupply(uint256 totalSupply_) public {
+        totalSupply = totalSupply_;
     }
 
-    function __setScaledTotalSupply(uint256 _scaledTotalSupply) public {
-        scaledTotalSupply = _scaledTotalSupply;
+    function __setScaledTotalSupply(uint256 scaledTotalSupply_) public {
+        scaledTotalSupply = scaledTotalSupply_;
     }
 
-    function __setDecimals(uint256 _decimals) public {
-        decimals = _decimals;
+    function __setDecimals(uint256 decimals_) public {
+        decimals = decimals_;
     }
 
 }


### PR DESCRIPTION
Adds role-based access control (RBAC) to the CapAutomator contract, replacing direct owner-only access with a more flexible permissioning system. Updates the interface to reflect the new access control mechanism. Includes comprehensive unit tests covering all RBAC scenarios and fixes integration tests to work with the new permissioning model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role-based access control with separate Admin and Updater roles; constructor now accepts admin/updater addresses.
  * Registry-driven wiring and new lightweight protocol interfaces for pool/provider interactions; added ERC20-like helpers.

* **Tests**
  * Tests, integration flows, harnesses, and mocks updated for Admin/Updater patterns and registry-based initialization; expanded role coverage.

* **Chores**
  * Added address-registry submodule, CI checks out submodules recursively, coverage filter relaxed, and Solidity compiler bumped to 0.8.22.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->