### PR TITLE
Fix: Use reserve-configuration decimals to mirror Aave cap math exactly (DEV-1225)

### DIFF
--- a/src/CapAutomator.sol
+++ b/src/CapAutomator.sol
@@ -190,7 +190,7 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
                 IScaledBalanceTokenLike(reserveData.aTokenAddress).scaledTotalSupply()
                 + uint256(reserveData.accruedToTreasury)
             ).rayMul(reserveData.liquidityIndex)
-            / 10 ** IERC20Like(reserveData.aTokenAddress).decimals();
+            / 10 ** reserveData.configuration.getDecimals();
 
         uint256 newSupplyCap = _calculateNewCap(
             capConfig,
@@ -224,7 +224,7 @@ contract CapAutomator is ICapAutomator, AccessControlEnumerable {
         // `stableDebt` is not in use and is always 0
         uint256 currentBorrow =
             IERC20Like(reserveData.variableDebtTokenAddress).totalSupply()
-            / 10 ** IERC20Like(reserveData.variableDebtTokenAddress).decimals();
+            / 10 ** reserveData.configuration.getDecimals();
 
         uint256 newBorrowCap = _calculateNewCap(
             capConfig,

--- a/test/CapAutomator.t.sol
+++ b/test/CapAutomator.t.sol
@@ -44,15 +44,13 @@ contract CapAutomatorUnitTestBase is Test {
 
         mockPool.__setSupplyCap(7_000);
 
-        MockToken(mockPool.aToken()).__setDecimals(18);
+        mockPool.__setDecimals(18);
         mockPool.__setATokenScaledTotalSupply(5_700e18);
         mockPool.__setAccruedToTreasury(50e18);
         mockPool.__setLiquidityIndex(1.2e27);
         // (aToken. scaledTotalSupply + accruedToTreasury) * liquidityIndex = 6_900e18
 
         mockPool.__setBorrowCap(4_000);
-
-        MockToken(mockPool.debtToken()).__setDecimals(18);
         mockPool.__setTotalDebt(3_900e18);
 
         capAutomator = new CapAutomator(address(mockPoolAddressesProvider), admin, updater1);
@@ -1294,7 +1292,7 @@ contract ExecSupplyTests is CapAutomatorUnitTestBase {
         vm.roll(300);
         vm.warp(300_000 seconds);
 
-        MockToken(mockPool.aToken()).__setDecimals(6);
+        mockPool.__setDecimals(6);
         mockPool.__setATokenScaledTotalSupply(4_500e6);
         mockPool.__setAccruedToTreasury(100e6);
         mockPool.__setLiquidityIndex(1.5e27);
@@ -1558,7 +1556,7 @@ contract ExecBorrowTests is CapAutomatorUnitTestBase {
         vm.roll(200);
         vm.warp(200_000 seconds);
 
-        MockToken(mockPool.debtToken()).__setDecimals(6);
+        mockPool.__setDecimals(6);
         mockPool.__setTotalDebt(3_900e6);
 
         vm.prank(admin);

--- a/test/mocks/MockPool.sol
+++ b/test/mocks/MockPool.sol
@@ -23,6 +23,8 @@ contract MockPool {
     uint256 public supplyCap;
     uint256 public borrowCap;
 
+    uint256 public decimals;
+
     constructor() {
         aToken    = address(new MockToken());
         debtToken = address(new MockToken());
@@ -38,6 +40,8 @@ contract MockPool {
 
         configuration.setBorrowCap(borrowCap);
         configuration.setSupplyCap(supplyCap);
+
+        configuration.setDecimals(decimals);
 
         return DataTypes.ReserveData({
             configuration:               configuration,
@@ -84,6 +88,10 @@ contract MockPool {
 
     function __setAccruedToTreasury(uint256 accruedToTreasury_) external {
         accruedToTreasury = accruedToTreasury_;
+    }
+
+    function __setDecimals(uint256 decimals_) external {
+        decimals = decimals_;
     }
 
 }


### PR DESCRIPTION
https://github.com/cantinasec/sky-review-020226/issues/13

Validated Audit issue. 

1. aToken decimals == underlying asset decimals — Confirmed via Aave V3 `AToken.initialize()` which receives underlyingAssetDecimals and stores it as the aToken's decimals
2. All Aave V3 token types (aToken, stableDebtToken, variableDebtToken) share the same decimals as the underlying. Same initialization pattern applies to all tokenization contracts
3. `reserveConfiguration.getDecimals() == token decimals` . The decimals stored in the configuration bitmap are the underlyingAssetDecimals set at reserve init time, same value passed to all tokens
4. Aave's canonical cap-check math uses `configuration.getDecimals()`, not token.decimals() in `ValidationLogic.sol` for both validateSupply and validateBorrow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated decimal calculation for supply and borrow capacity to use consistent configuration source.

* **Tests**
  * Refined test utilities to align with updated decimal configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->